### PR TITLE
MEL-71: Add pipeline notifications to image-viewer pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,15 +3,23 @@ The "Infrastructure as Code" repo for all pieces in the Mellon Grant. Will conta
 
 Note: It is highly recommended you use something like https://github.com/awslabs/git-secrets to prevent pushing AWS secrets to the repo
 
+# Requirements
+Before you begin, check that you have the following:
+  - A role with permissions to deploy cloudformations. In most cases, will require permissions to create IAM roles/policies (see [Permissions Required to Access IAM Resources](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_permissions-required.html))
+  - Ability to manage DNS for your organization to validate certificates (see [Use DNS to Validate Domain Ownership](https://docs.aws.amazon.com/acm/latest/userguide/gs-acm-validate-dns.html))
+  - A policy that allows your approvers to approve pipelines (see [Grant Approval Permissions to an IAM User in AWS CodePipeline](https://docs.aws.amazon.com/codepipeline/latest/userguide/approvals-iam-permissions.html))
+  - Must have awscli installed if using the example deploy commands
+
 # Deploy
 TODO:
 * [ ] Add stack diagram. Important to note the Network and App-Infrastructure stacks are intended to be shared per env. Ex: Only one of each of these exist in dev, but you can have multiple dev instances of service/webcomponent stacks for each developer.
-* [ ] Explain why we have the separation we do, reference https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/best-practices.html#organizingstacks
+* [ ] Explain why we have the separation we do, reference [Organize Your Stacks By Lifecycle and Ownership](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/best-practices.html#organizingstacks)
 
 ## Deploy Shared Infrastructure
 Before you can deploy any of the other stacks, you must deploy some prerequisite pieces of shared infrastructure. These are required by both the application components and the CI/CD stacks that test and deploy those application components.
 
 ### Network stack
+
 ```console
 aws cloudformation deploy \
   --capabilities CAPABILITY_IAM \
@@ -77,10 +85,60 @@ This will deploy to test, then to production, so it expects two different image-
 ```console
 aws cloudformation deploy \
   --capabilities CAPABILITY_IAM \
-  --stack-name mellon-image-webcomponent-pipeline-prod \
+  --stack-name mellon-image-webcomponent-pipeline \
   --template-file deploy/cloudformation/iiif-webcomponent-pipeline.yml \
   --tags ProjectName=mellon \
   --parameter-overrides OAuth=my_oauth_key Approvers=me@myhost.com \
-    TestManifestURL='http://wellcomelibrary.org/iiif/b18035723/manifest' \
-    NameTag='testaccount-mellonimagewebcomponentpipeline-prod' ContactTag='me@myhost.com' OwnerTag='myid'
+    NameTag='testaccount-mellonimagewebcomponentpipeline' ContactTag='me@myhost.com' OwnerTag='myid'
+```
+
+
+#### Approval message
+Once the pipeline reaches the UAT step, it will send an email to the approvers list and wait until it's either approved or rejected. Here's an example of the message.
+
+```email
+Approve or reject: https://console.aws.amazon.com/codepipeline/home?region=us-west-2#/view/mellon-image-webcomponent-pipeline-CodePipeline-ID/Approval/ManualApprovalOfTestEnvironment/approve/approval-id
+Additional information: You can review these changes at https://testurl. Once approved, this will be deployed to https://produrl.
+Deadline: This review request will expire on 2018-10-15T20:36Z
+```
+
+The link given in the email will take the user directly to the approval modal:
+
+* [ ] Add screenshot of approval here
+
+Note: The user must be logged in and have the appropriate permissions to approve pipelines.
+
+### IIIF Image Viewer Pipeline Monitoring
+Use this stack if you want to notify an email address of pipeline events. It is currently written to only accept a single email address, so it's recommended you use a mailing list for the Receivers parameter.
+
 ```console
+aws cloudformation deploy \
+  --stack-name mellon-image-webcomponent-pipeline-monitoring \
+  --template-file deploy/cloudformation/pipeline-monitoring.yml \
+  --tags ProjectName=mellon \
+  --parameter-overrides PipelineStackName=mellon-image-webcomponent-pipeline Receivers=me@myhost.com \
+    NameTag='testaccount-mellonimagewebcomponentpipelinemonitor' ContactTag='me@myhost.com' OwnerTag='myid'
+```
+
+#### Examples of the notifications:
+##### Started
+"The pipeline mellon-image-webcomponent-pipeline has started. To view the pipeline, go to https://us-west-2.console.aws.amazon.com/codepipeline/home?region=us-west-2#/view/mellon-image-webcomponent-pipeline-CodePipeline-ID."
+##### Success
+"The pipeline mellon-image-webcomponent-pipeline has successfully deployed to production. To view the pipeline, go to https://us-west-2.console.aws.amazon.com/codepipeline/home?region=us-west-2#/view/mellon-image-webcomponent-pipeline-CodePipeline-ID."
+##### Source failure
+"Failed to pull the source code for mellon-image-webcomponent-pipeline. To view the current execution, go to https://us-west-2.console.aws.amazon.com/codepipeline/home?region=us-west-2#/view/mellon-image-webcomponent-pipeline-CodePipeline-ID."
+
+##### Build failure
+"Failed to build mellon-image-webcomponent-pipeline. To view the pipeline, go to https://us-west-2.console.aws.amazon.com/codepipeline/home?region=us-west-2#/view/mellon-image-webcomponent-pipeline-CodePipeline-ID."
+
+##### Deploy to test failure
+"Build for mellon-image-webcomponent-pipeline failed to deploy to test stack. To view the pipeline, go to https://us-west-2.console.aws.amazon.com/codepipeline/home?region=us-west-2#/view/mellon-image-webcomponent-pipeline-CodePipeline-ID."
+
+##### Approval failure
+"Build for mellon-image-webcomponent-pipeline was rejected by an approver. To view the pipeline, go to https://us-west-2.console.aws.amazon.com/codepipeline/home?region=us-west-2#/view/mellon-image-webcomponent-pipeline-CodePipeline-ID."
+
+##### Deploy to production failure
+"Build for mellon-image-webcomponent-pipeline failed to deploy to production. To view the pipeline, go to https://us-west-2.console.aws.amazon.com/codepipeline/home?region=us-west-2#/view/mellon-image-webcomponent-pipeline-CodePipeline-ID."
+
+##### Generic resume after a failure
+"The pipeline mellon-image-webcomponent-pipeline has changed state to RESUMED. To view the pipeline, go to https://us-west-2.console.aws.amazon.com/codepipeline/home?region=us-west-2#/view/mellon-image-webcomponent-pipeline-CodePipeline-ID."

--- a/README.md
+++ b/README.md
@@ -78,6 +78,17 @@ aws cloudformation deploy \
 Before you begin see https://developer.github.com/v3/auth/#via-oauth-tokens for how to generate an OAuth token for use with these pipelines.
 
 ### IIIF Image Service Pipeline
+This will deploy to test, then to production, so it expects two different image-viewer stacks to exist, ex: "mellon-image-webcomponent-test" and "mellon-image-webcomponent-prod". If custom stack names were used for the image-viewer stacks, you'll need to override the default parameter store paths for TestDeployBucket, TestURL, ProdDeployBucket, and ProdURL.
+
+```console
+aws cloudformation deploy \
+  --capabilities CAPABILITY_IAM \
+  --stack-name mellon-image-service-pipeline \
+  --template-file deploy/cloudformation/iiif-service-pipeline.yml \
+  --tags ProjectName=mellon \
+  --parameter-overrides OAuth=my_oauth_key Approvers=me@myhost.com \
+    NameTag='testaccount-mellonimageservicepipeline' ContactTag='me@myhost.com' OwnerTag='myid'
+```
 
 ### IIIF Image Viewer Pipeline
 This will deploy to test, then to production, so it expects two different image-viewer stacks to exist, ex: "mellon-image-webcomponent-test" and "mellon-image-webcomponent-prod". If custom stack names were used for the image-viewer stacks, you'll need to override the default parameter store paths for TestDeployBucket, TestURL, ProdDeployBucket, and ProdURL.
@@ -108,37 +119,48 @@ The link given in the email will take the user directly to the approval modal:
 
 Note: The user must be logged in and have the appropriate permissions to approve pipelines.
 
-### IIIF Image Viewer Pipeline Monitoring
+### Pipeline Monitoring
 Use this stack if you want to notify an email address of pipeline events. It is currently written to only accept a single email address, so it's recommended you use a mailing list for the Receivers parameter.
 
+Here's an example of adding monitoring to the image-webcomponent-pipeline
 ```console
 aws cloudformation deploy \
   --stack-name mellon-image-webcomponent-pipeline-monitoring \
   --template-file deploy/cloudformation/pipeline-monitoring.yml \
   --tags ProjectName=mellon \
-  --parameter-overrides PipelineStackName=mellon-image-webcomponent-pipeline Receivers=me@myhost.com \
-    NameTag='testaccount-mellonimagewebcomponentpipelinemonitor' ContactTag='me@myhost.com' OwnerTag='myid'
+  --parameter-overrides PipelineStackName=mellon-image-webcomponent-pipeline Receivers=me@myhost.com
+```
+
+Here's an example of adding monitoring to the image-service-pipeline
+```console
+aws cloudformation deploy \
+  --stack-name mellon-image-service-pipeline-monitoring \
+  --template-file deploy/cloudformation/pipeline-monitoring.yml \
+  --tags ProjectName=mellon \
+  --parameter-overrides PipelineStackName=mellon-image-service-pipeline Receivers=me@myhost.com
 ```
 
 #### Examples of the notifications:
 ##### Started
-"The pipeline mellon-image-webcomponent-pipeline has started. To view the pipeline, go to https://us-west-2.console.aws.amazon.com/codepipeline/home?region=us-west-2#/view/mellon-image-webcomponent-pipeline-CodePipeline-ID."
+The pipeline mellon-image-webcomponent-pipeline has started. To view the pipeline, go to https://us-west-2.console.aws.amazon.com/codepipeline/home?region=us-west-2#/view/mellon-image-webcomponent-pipeline-CodePipeline-ID.
+
 ##### Success
-"The pipeline mellon-image-webcomponent-pipeline has successfully deployed to production. To view the pipeline, go to https://us-west-2.console.aws.amazon.com/codepipeline/home?region=us-west-2#/view/mellon-image-webcomponent-pipeline-CodePipeline-ID."
+The pipeline mellon-image-webcomponent-pipeline has successfully deployed to production. To view the pipeline, go to https://us-west-2.console.aws.amazon.com/codepipeline/home?region=us-west-2#/view/mellon-image-webcomponent-pipeline-CodePipeline-ID.
+
 ##### Source failure
-"Failed to pull the source code for mellon-image-webcomponent-pipeline. To view the current execution, go to https://us-west-2.console.aws.amazon.com/codepipeline/home?region=us-west-2#/view/mellon-image-webcomponent-pipeline-CodePipeline-ID."
+Failed to pull the source code for mellon-image-webcomponent-pipeline. To view the current execution, go to https://us-west-2.console.aws.amazon.com/codepipeline/home?region=us-west-2#/view/mellon-image-webcomponent-pipeline-CodePipeline-ID.
 
 ##### Build failure
-"Failed to build mellon-image-webcomponent-pipeline. To view the pipeline, go to https://us-west-2.console.aws.amazon.com/codepipeline/home?region=us-west-2#/view/mellon-image-webcomponent-pipeline-CodePipeline-ID."
+Failed to build mellon-image-webcomponent-pipeline. To view the pipeline, go to https://us-west-2.console.aws.amazon.com/codepipeline/home?region=us-west-2#/view/mellon-image-webcomponent-pipeline-CodePipeline-ID.
 
 ##### Deploy to test failure
-"Build for mellon-image-webcomponent-pipeline failed to deploy to test stack. To view the pipeline, go to https://us-west-2.console.aws.amazon.com/codepipeline/home?region=us-west-2#/view/mellon-image-webcomponent-pipeline-CodePipeline-ID."
+Build for mellon-image-webcomponent-pipeline failed to deploy to test stack. To view the pipeline, go to https://us-west-2.console.aws.amazon.com/codepipeline/home?region=us-west-2#/view/mellon-image-webcomponent-pipeline-CodePipeline-ID.
 
 ##### Approval failure
-"Build for mellon-image-webcomponent-pipeline was rejected by an approver. To view the pipeline, go to https://us-west-2.console.aws.amazon.com/codepipeline/home?region=us-west-2#/view/mellon-image-webcomponent-pipeline-CodePipeline-ID."
+Build for mellon-image-webcomponent-pipeline was rejected either due to a QA failure or UAT rejection. To view the pipeline, go to https://us-west-2.console.aws.amazon.com/codepipeline/home?region=us-west-2#/view/mellon-image-webcomponent-pipeline-CodePipeline-ID.
 
 ##### Deploy to production failure
-"Build for mellon-image-webcomponent-pipeline failed to deploy to production. To view the pipeline, go to https://us-west-2.console.aws.amazon.com/codepipeline/home?region=us-west-2#/view/mellon-image-webcomponent-pipeline-CodePipeline-ID."
+Build for mellon-image-webcomponent-pipeline failed to deploy to production. To view the pipeline, go to https://us-west-2.console.aws.amazon.com/codepipeline/home?region=us-west-2#/view/mellon-image-webcomponent-pipeline-CodePipeline-ID.
 
 ##### Generic resume after a failure
-"The pipeline mellon-image-webcomponent-pipeline has changed state to RESUMED. To view the pipeline, go to https://us-west-2.console.aws.amazon.com/codepipeline/home?region=us-west-2#/view/mellon-image-webcomponent-pipeline-CodePipeline-ID."
+The pipeline mellon-image-webcomponent-pipeline has changed state to RESUMED. To view the pipeline, go to https://us-west-2.console.aws.amazon.com/codepipeline/home?region=us-west-2#/view/mellon-image-webcomponent-pipeline-CodePipeline-ID.

--- a/deploy/cloudformation/iiif-service-pipeline.yml
+++ b/deploy/cloudformation/iiif-service-pipeline.yml
@@ -14,20 +14,21 @@ Description: >
 
 Parameters:
 
-  TestUrl:
-    Type: String
-    Description: The URL to test against for newman QA specs
+  TestURL:
+    Type: 'AWS::SSM::Parameter::Value<String>'
+    Description: The path to the param that stores the test URL.
+    Default: "/all/stacks/mellon-image-service-test/url"
   Approvers:
     Type: String
     Default: ''
     Description: An e-mail address of someone who can approve test environment
   IIIFProdServiceStackName:
     Type: String
-    Default: mellon-iiif-service
+    Default: mellon-image-service-prod
     Description: The name of the CloudFormation stack that created the production ECS Service
   IIIFTestServiceStackName:
     Type: String
-    Default: mellon-iiif-test-service
+    Default: mellon-image-service-test
     Description: The name of the CloudFormation stack that created the test ECS Service
   InfrastructureStackName:
     Type: String
@@ -54,6 +55,12 @@ Parameters:
     Description: The OAuth Token Value to connect CodePipeline to GitHub. Passed in at Runtime.
 
 Outputs:
+
+  PipelineName:
+    Description: The name of the pipeline created by this stack
+    Value: !Ref CodePipeline
+    Export:
+      Name: !Join [ ':', [ !Ref 'AWS::StackName', 'PipelineName']]
 
   ContainerRepositoryName:
     Description: Name of the created container repository
@@ -155,7 +162,7 @@ Resources:
         Image: aws/codebuild/nodejs:10.1.0
         EnvironmentVariables:
           - Name: TESTING_URL
-            Value: !Ref TestUrl
+            Value: !Ref TestURL
 
   DockerCodePipelineBuilder:
     Type: 'AWS::CodeBuild::Project'

--- a/deploy/cloudformation/iiif-service.yml
+++ b/deploy/cloudformation/iiif-service.yml
@@ -98,6 +98,14 @@ Outputs:
 
 Resources:
 
+  URLParameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Type: String
+      Name: !Sub "/all/stacks/${AWS::StackName}/url"
+      Value: !GetAtt PublicLoadBalancer.DNSName
+      Description: The URL endpoint for this component
+
   # The task definition. This is a simple metadata description of what
   # container to run, and what resource requirements it has.
   TaskDefinition:

--- a/deploy/cloudformation/iiif-webcomponent-pipeline.yml
+++ b/deploy/cloudformation/iiif-webcomponent-pipeline.yml
@@ -14,18 +14,10 @@ Parameters:
     Type: String
     Description: An e-mail address of someone who can approve test environment
 
-  InfrastructureStackName:
-    Type: String
-    Default: mellon-app-infrastructure
-    Description: The name of the parent infrastructure/networking stack that you created. Necessary
-                 to locate and reference resources created by that stack.
-
   CDBranchName:
     Type: String
     Default: master
     Description: The name of the branch to watch for continuous deployment
-
-  # TODO: Optional param to stop at continuous delivery vs deployment?
 
   NameTag:
     Type: String
@@ -66,14 +58,22 @@ Parameters:
     Description: The path to the param that stores the test URL.
     Default: "/all/stacks/mellon-image-webcomponent-prod/url"
 
+Outputs:
+
+  PipelineName:
+    Description: The name of the pipeline created by this stack
+    Value: !Ref CodePipeline
+    Export:
+      Name: !Join [ ':', [ !Ref 'AWS::StackName', 'PipelineName']]
+
 Resources:
-  SNSTopic:
+  ApproversTopic:
     Type: AWS::SNS::Topic
 
-  SNSTopicSubscription:
+  ApproversTopicSubscription:
     Type: AWS::SNS::Subscription
     Properties:
-      TopicArn: !Ref SNSTopic
+      TopicArn: !Ref ApproversTopic
       Protocol: email
       Endpoint: !Ref Approvers
 
@@ -292,14 +292,21 @@ Resources:
       TimeoutInMinutes: 10
       Source:
         Type: CODEPIPELINE
+        # This buildspec will first empty the bucket, then copy all files into it
+        # This may be the only way to reliably sync the complete state of the
+        # files to the bucket. Multiple back to back invocations of the pipeline
+        # has caused new changes to fail to deploy when using aws s3 sync, possibly
+        # due to the eventual consistency nature of s3.
         BuildSpec: |
           version: 0.2
 
           phases:
-            post_build:
+            pre_build:
               commands:
-                - echo Beginning deploy on `date`
-                - aws s3 sync --delete . s3://$DEST_BUCKET/
+                - aws s3 rm s3://$DEST_BUCKET --recursive
+            build:
+              commands:
+                - aws s3 cp --recursive . s3://$DEST_BUCKET/
 
       Artifacts:
         Type: CODEPIPELINE
@@ -320,14 +327,22 @@ Resources:
       TimeoutInMinutes: 10
       Source:
         Type: CODEPIPELINE
+        # This buildspec will first empty the bucket, then copy all files into it
+        # This may be the only way to reliably sync the complete state of the
+        # files to the bucket. Multiple back to back invocations of the pipeline
+        # has caused new changes to fail to deploy when using aws s3 sync, possibly
+        # due to the eventual consistency nature of s3. See
+        # https://docs.aws.amazon.com/AmazonS3/latest/dev/Introduction.html#ConsistencyModel
         BuildSpec: |
           version: 0.2
 
           phases:
-            post_build:
+            pre_build:
               commands:
-                - echo Beginning deploy on `date`
-                - aws s3 sync --delete . s3://$DEST_BUCKET/
+                - aws s3 rm s3://$DEST_BUCKET --recursive
+            build:
+              commands:
+                - aws s3 cp --recursive . s3://$DEST_BUCKET/
 
       Artifacts:
         Type: CODEPIPELINE
@@ -490,7 +505,7 @@ Resources:
                 Provider: Manual
                 Version: "1"
               Configuration:
-                NotificationArn: !Ref SNSTopic
+                NotificationArn: !Ref ApproversTopic
                 CustomData: !Sub "You can review these changes at https://${TestURL}. Once approved, this will be deployed to https://${ProdURL}."
 
         -

--- a/deploy/cloudformation/iiif-webcomponent.yml
+++ b/deploy/cloudformation/iiif-webcomponent.yml
@@ -36,7 +36,10 @@ Parameters:
     ConstraintDescription: must specify prod or dev.
 
 Mappings:
-  # Cache settings to use for each environment
+  # Cache settings to use for each environment.
+  # Note: Our current pipeline's deploy cannot do an atomic cutover when deploying a new version to production.
+  # It's best to make sure that the DefaultTTL in production covers the gap between the delete->copy commands.
+  # See CodeProdDeployer within https://github.com/ndlib/mellon-blueprints/blob/master/deploy/cloudformation/iiif-webcomponent-pipeline.yml
   CacheSettings:
     dev:
       DefaultTTL: 0

--- a/deploy/cloudformation/pipeline-monitoring.yml
+++ b/deploy/cloudformation/pipeline-monitoring.yml
@@ -1,0 +1,265 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: >
+  Creates set of CloudWatch Event Rules to monitor a CI/CD pipeline.
+  The target pipleine must have the following build stages:
+    Source, Build, DeployToTest, Approval, DeployToProduction
+
+  Expects the following exports from the target pipeline stack:
+    - PipelineStackName:PipelineName
+
+Parameters:
+  PipelineStackName:
+    Type: String
+    Description: The name of the parent stack that created the pipeline to observe.
+
+  Receivers:
+    Type: String
+    Description: An e-mail address to send the notifications to
+
+Resources:
+
+  PipelineEventsTopic:
+    Type: AWS::SNS::Topic
+
+  PipelineEventsTopicSubscription:
+    Type: AWS::SNS::Subscription
+    Properties:
+      TopicArn: !Ref PipelineEventsTopic
+      Protocol: email
+      Endpoint: !Ref Receivers
+
+  # Allow events below to publish to the pipeline events topic
+  EventTopicPolicy:
+    Type: 'AWS::SNS::TopicPolicy'
+    Properties:
+      PolicyDocument:
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: events.amazonaws.com
+            Action: 'sns:Publish'
+            Resource: !Ref PipelineEventsTopic
+      Topics:
+        - !Ref PipelineEventsTopic
+
+  # Top level pipeline change events
+  PipelineStartedEventRule:
+    Type: AWS::Events::Rule
+    Properties:
+      Description: "Sends pipeline started message to pipeline events topic."
+      EventPattern:
+        source:
+          - aws.codepipeline
+        detail-type:
+          - "CodePipeline Pipeline Execution State Change"
+        detail:
+          pipeline:
+            - Fn::ImportValue: !Join [':', [!Ref PipelineStackName, 'PipelineName']]
+          state:
+            - STARTED
+      State: "ENABLED"
+      Targets:
+        -
+          Arn:
+            Ref: "PipelineEventsTopic"
+          Id: "PipelineEventsTopic"
+          InputTransformer:
+            InputPathsMap:
+              Pipeline: "$.detail.pipeline"
+            InputTemplate: !Sub '"The pipeline ${AWS::StackName} has started. To view the pipeline, go to https://${AWS::Region}.console.aws.amazon.com/codepipeline/home?region=${AWS::Region}#/view/<Pipeline>."'
+
+  PipelineSuccessEventRule:
+    Type: AWS::Events::Rule
+    Properties:
+      Description: "Sends pipeline succeeded message to pipeline events topic."
+      EventPattern:
+        source:
+          - aws.codepipeline
+        detail-type:
+          - "CodePipeline Pipeline Execution State Change"
+        detail:
+          pipeline:
+            - Fn::ImportValue: !Join [':', [!Ref PipelineStackName, 'PipelineName']]
+          state:
+            - SUCCEEDED
+      State: "ENABLED"
+      Targets:
+        -
+          Arn:
+            Ref: "PipelineEventsTopic"
+          Id: "PipelineEventsTopic"
+          InputTransformer:
+            InputPathsMap:
+              Pipeline: "$.detail.pipeline"
+            InputTemplate: !Sub '"The pipeline ${AWS::StackName} has successfully deployed to production. To view the pipeline, go to https://${AWS::Region}.console.aws.amazon.com/codepipeline/home?region=${AWS::Region}#/view/<Pipeline>."'
+
+  # This is just a catch all for other states.
+  # I'm not entirely sure we care about them yet.
+  PipelineGenericEventRule:
+    Type: AWS::Events::Rule
+    Properties:
+      Description: "Sends generic pipeline state change messages to the pipeline events topic."
+      EventPattern:
+        source:
+          - aws.codepipeline
+        detail-type:
+          - "CodePipeline Pipeline Execution State Change"
+        detail:
+          pipeline:
+            - Fn::ImportValue: !Join [':', [!Ref PipelineStackName, 'PipelineName']]
+          state:
+            - RESUMED
+            - CANCELED
+            - SUPERSEDED
+      State: "ENABLED"
+      Targets:
+        -
+          Arn:
+            Ref: "PipelineEventsTopic"
+          Id: "PipelineEventsTopic"
+          InputTransformer:
+            InputPathsMap:
+              Pipeline: "$.detail.pipeline"
+              PipelineState: "$.detail.state"
+            InputTemplate: !Sub '"The pipeline ${AWS::StackName} has changed state to <PipelineState>. To view the pipeline, go to https://${AWS::Region}.console.aws.amazon.com/codepipeline/home?region=${AWS::Region}#/view/<Pipeline>."'
+
+  # Stage failure events
+  # I couldn't get anything meaningful out of a generic pipeline-level failure
+  # so I am adding one for each stage. This may eventually need to go through
+  # a more sophisticated event processor to give more useful information.
+  SourceFailureEventRule:
+    Type: AWS::Events::Rule
+    Properties:
+      Description: "Sends source code stage failure message to pipeline events topic."
+      EventPattern:
+        source:
+          - aws.codepipeline
+        detail-type:
+          - "CodePipeline Stage Execution State Change"
+        detail:
+          pipeline:
+            - Fn::ImportValue: !Join [':', [!Ref PipelineStackName, 'PipelineName']]
+          stage:
+            - "Source"
+          state:
+            - FAILED
+      State: "ENABLED"
+      Targets:
+        -
+          Arn:
+            Ref: "PipelineEventsTopic"
+          Id: "PipelineEventsTopic"
+          InputTransformer:
+            InputPathsMap:
+              Pipeline: "$.detail.pipeline"
+              Json: "$"
+            InputTemplate: !Sub '"Failed to pull the source code for ${AWS::StackName}. To view the current execution, go to https://${AWS::Region}.console.aws.amazon.com/codepipeline/home?region=${AWS::Region}#/view/<Pipeline>."'
+
+  BuildFailureEventRule:
+    Type: AWS::Events::Rule
+    Properties:
+      Description: "Sends build stage failure message to pipeline events topic."
+      EventPattern:
+        source:
+          - aws.codepipeline
+        detail-type:
+          - "CodePipeline Stage Execution State Change"
+        detail:
+          pipeline:
+            - Fn::ImportValue: !Join [':', [!Ref PipelineStackName, 'PipelineName']]
+          stage:
+            - "Build"
+          state:
+            - FAILED
+      State: "ENABLED"
+      Targets:
+        -
+          Arn:
+            Ref: "PipelineEventsTopic"
+          Id: "PipelineEventsTopic"
+          InputTransformer:
+            InputPathsMap:
+              Pipeline: "$.detail.pipeline"
+              Json: "$"
+            InputTemplate: !Sub '"Failed to build ${AWS::StackName}. To view the pipeline, go to https://${AWS::Region}.console.aws.amazon.com/codepipeline/home?region=${AWS::Region}#/view/<Pipeline>."'
+
+  DeployToTestFailureEventRule:
+    Type: AWS::Events::Rule
+    Properties:
+      Description: "Sends deploy to test stage failure message to pipeline events topic."
+      EventPattern:
+        source:
+          - aws.codepipeline
+        detail-type:
+          - "CodePipeline Stage Execution State Change"
+        detail:
+          pipeline:
+            - Fn::ImportValue: !Join [':', [!Ref PipelineStackName, 'PipelineName']]
+          stage:
+            - "DeployToTest"
+          state:
+            - FAILED
+      State: "ENABLED"
+      Targets:
+        -
+          Arn:
+            Ref: "PipelineEventsTopic"
+          Id: "PipelineEventsTopic"
+          InputTransformer:
+            InputPathsMap:
+              Pipeline: "$.detail.pipeline"
+            InputTemplate: !Sub '"Build for ${AWS::StackName} failed to deploy to test stack. To view the pipeline, go to https://${AWS::Region}.console.aws.amazon.com/codepipeline/home?region=${AWS::Region}#/view/<Pipeline>."'
+
+  ApprovalFailureEventRule:
+    Type: AWS::Events::Rule
+    Properties:
+      Description: "Sends approval stage failure message to pipeline events topic."
+      EventPattern:
+        source:
+          - aws.codepipeline
+        detail-type:
+          - "CodePipeline Stage Execution State Change"
+        detail:
+          pipeline:
+            - Fn::ImportValue: !Join [':', [!Ref PipelineStackName, 'PipelineName']]
+          stage:
+            - "Approval"
+          state:
+            - FAILED
+      State: "ENABLED"
+      Targets:
+        -
+          Arn:
+            Ref: "PipelineEventsTopic"
+          Id: "PipelineEventsTopic"
+          InputTransformer:
+            InputPathsMap:
+              Pipeline: "$.detail.pipeline"
+            InputTemplate: !Sub '"Build for ${AWS::StackName} was rejected by an approver. To view the pipeline, go to https://${AWS::Region}.console.aws.amazon.com/codepipeline/home?region=${AWS::Region}#/view/<Pipeline>."'
+
+  DeployToProdFailureEventRule:
+    Type: AWS::Events::Rule
+    Properties:
+      Description: "Sends deploy to production stage failure message to pipeline events topic."
+      EventPattern:
+        source:
+          - aws.codepipeline
+        detail-type:
+          - "CodePipeline Stage Execution State Change"
+        detail:
+          pipeline:
+            - Fn::ImportValue: !Join [':', [!Ref PipelineStackName, 'PipelineName']]
+          stage:
+            - "DeployToProduction"
+          state:
+            - FAILED
+      State: "ENABLED"
+      Targets:
+        -
+          Arn:
+            Ref: "PipelineEventsTopic"
+          Id: "PipelineEventsTopic"
+          InputTransformer:
+            InputPathsMap:
+              Pipeline: "$.detail.pipeline"
+            InputTemplate: !Sub '"Build for ${AWS::StackName} failed to deploy to production stack. To view the pipeline, go to https://${AWS::Region}.console.aws.amazon.com/codepipeline/home?region=${AWS::Region}#/view/<Pipeline>."'

--- a/deploy/cloudformation/pipeline-monitoring.yml
+++ b/deploy/cloudformation/pipeline-monitoring.yml
@@ -235,7 +235,7 @@ Resources:
           InputTransformer:
             InputPathsMap:
               Pipeline: "$.detail.pipeline"
-            InputTemplate: !Sub '"Build for ${AWS::StackName} was rejected by an approver. To view the pipeline, go to https://${AWS::Region}.console.aws.amazon.com/codepipeline/home?region=${AWS::Region}#/view/<Pipeline>."'
+            InputTemplate: !Sub '"Build for ${AWS::StackName} was rejected either due to a QA failure or UAT rejection. To view the pipeline, go to https://${AWS::Region}.console.aws.amazon.com/codepipeline/home?region=${AWS::Region}#/view/<Pipeline>."'
 
   DeployToProdFailureEventRule:
     Type: AWS::Events::Rule


### PR DESCRIPTION
## Add pipeline notifications to image-viewer pipeline

4f61525aa476144bd564e9e39af95533dcaea372

This adds a new pipeline-monitoring template that will add CloudWatch event rules for the state changes of a pipeline that we care about. Ideally we'll be able to use this against any pipeline that follows our CI/CD stages of Source, Build, DeployToTest, Approval, and DeployToProduction. There are 3 rules that observe at the pipeline level, and the rest are at the stage level (see [Detect and React to Changes in Pipeline State with Amazon CloudWatch Events](https://docs.aws.amazon.com/codepipeline/latest/userguide/detect-state-changes-cloudwatch-events.html)).

Pipeline-level events:
- When the pipeline starts, it will email that a build has started and will attempt to deploy to production
- When the pipeline successfully finishes, it will email a notification that it has finished deploying to production
- When the pipeline enters the RESUMED, CANCELED, or SUPERSEDED states. These may be pretty rare, but I added a generic catch all rule so that we see them.

Stage-level:
- These are all context specific messages for failures at each of the different stages. I wasn't able to get a ton of information out of these events, so for now, they will just email a link to the pipeline for further troubleshooting.

Other cleanup/improvements
- Removed TestURL from example command for the webcomponent pipeline stack in README. The component currently does not read this from the url params, and was removed in a previous commit.
- Fixed a major bug with deploy steps in the webcomponent pipeline. Using s3 sync was inconsistent. Changed to perform a delete then a copy. This should be less sensitive to eventual consistency issues of s3.
- Added a bit to the README, including current examples of the pipeline notifications. Still needs a lot of work

## Add pipeline monitoring to image-service

8d8eef39f0590f661e3152e9392650a701afd526

This adds the ability to reuse the pipeline-monitoring template for both the iiif-service and iiif-webcomponent

Changes to iiif-service.yml:
- Changed the image service to add the test url to parameter store and changed the pipeline template to get the test url from parameter store. This is to simplify the amount of parameters required by the user

Changes to iiif-service-pipeline.yml:
- Pipeline monitoring stack requires an export of the stackname, so added
- Changed test url to pull from the new entry in parameter store that iiif-service.yml will now create
- Changed the default parameter values for the stack names to be more in line with our naming conventions for stack names

Changes to pipeline-monitoring:
- Reworded the approval notification a bit, since these service stacks have 2 steps within the Approval stage. It may prove more useful to eventually break these out into 2 different stages, but keeping it simple for now.

Changes to README.md:
- Added example of how to deploy the image-service pipeline and monitoring to the README