### PR TITLE
ESU-675: Bugfix pipeline name

### DIFF
--- a/deploy/cloudformation/iiif-service.yml
+++ b/deploy/cloudformation/iiif-service.yml
@@ -69,7 +69,7 @@ Parameters:
                  assigned to different paths on the load balancer.
   DesiredCount:
     Type: Number
-    Default: 2
+    Default: 1
     Description: How many copies of the service task to run
   NameTag:
     Type: String

--- a/deploy/cloudformation/pipeline-monitoring.yml
+++ b/deploy/cloudformation/pipeline-monitoring.yml
@@ -66,7 +66,7 @@ Resources:
           InputTransformer:
             InputPathsMap:
               Pipeline: "$.detail.pipeline"
-            InputTemplate: !Sub '"The pipeline ${AWS::StackName} has started. To view the pipeline, go to https://${AWS::Region}.console.aws.amazon.com/codepipeline/home?region=${AWS::Region}#/view/<Pipeline>."'
+            InputTemplate: !Sub '"The pipeline <Pipeline> has started. To view the pipeline, go to https://${AWS::Region}.console.aws.amazon.com/codepipeline/home?region=${AWS::Region}#/view/<Pipeline>."'
 
   PipelineSuccessEventRule:
     Type: AWS::Events::Rule
@@ -91,7 +91,7 @@ Resources:
           InputTransformer:
             InputPathsMap:
               Pipeline: "$.detail.pipeline"
-            InputTemplate: !Sub '"The pipeline ${AWS::StackName} has successfully deployed to production. To view the pipeline, go to https://${AWS::Region}.console.aws.amazon.com/codepipeline/home?region=${AWS::Region}#/view/<Pipeline>."'
+            InputTemplate: !Sub '"The pipeline <Pipeline> has successfully deployed to production. To view the pipeline, go to https://${AWS::Region}.console.aws.amazon.com/codepipeline/home?region=${AWS::Region}#/view/<Pipeline>."'
 
   # This is just a catch all for other states.
   # I'm not entirely sure we care about them yet.
@@ -121,7 +121,7 @@ Resources:
             InputPathsMap:
               Pipeline: "$.detail.pipeline"
               PipelineState: "$.detail.state"
-            InputTemplate: !Sub '"The pipeline ${AWS::StackName} has changed state to <PipelineState>. To view the pipeline, go to https://${AWS::Region}.console.aws.amazon.com/codepipeline/home?region=${AWS::Region}#/view/<Pipeline>."'
+            InputTemplate: !Sub '"The pipeline <Pipeline> has changed state to <PipelineState>. To view the pipeline, go to https://${AWS::Region}.console.aws.amazon.com/codepipeline/home?region=${AWS::Region}#/view/<Pipeline>."'
 
   # Stage failure events
   # I couldn't get anything meaningful out of a generic pipeline-level failure
@@ -153,7 +153,7 @@ Resources:
             InputPathsMap:
               Pipeline: "$.detail.pipeline"
               Json: "$"
-            InputTemplate: !Sub '"Failed to pull the source code for ${AWS::StackName}. To view the current execution, go to https://${AWS::Region}.console.aws.amazon.com/codepipeline/home?region=${AWS::Region}#/view/<Pipeline>."'
+            InputTemplate: !Sub '"Failed to pull the source code for <Pipeline>. To view the current execution, go to https://${AWS::Region}.console.aws.amazon.com/codepipeline/home?region=${AWS::Region}#/view/<Pipeline>."'
 
   BuildFailureEventRule:
     Type: AWS::Events::Rule
@@ -181,7 +181,7 @@ Resources:
             InputPathsMap:
               Pipeline: "$.detail.pipeline"
               Json: "$"
-            InputTemplate: !Sub '"Failed to build ${AWS::StackName}. To view the pipeline, go to https://${AWS::Region}.console.aws.amazon.com/codepipeline/home?region=${AWS::Region}#/view/<Pipeline>."'
+            InputTemplate: !Sub '"Failed to build <Pipeline>. To view the pipeline, go to https://${AWS::Region}.console.aws.amazon.com/codepipeline/home?region=${AWS::Region}#/view/<Pipeline>."'
 
   DeployToTestFailureEventRule:
     Type: AWS::Events::Rule
@@ -208,7 +208,7 @@ Resources:
           InputTransformer:
             InputPathsMap:
               Pipeline: "$.detail.pipeline"
-            InputTemplate: !Sub '"Build for ${AWS::StackName} failed to deploy to test stack. To view the pipeline, go to https://${AWS::Region}.console.aws.amazon.com/codepipeline/home?region=${AWS::Region}#/view/<Pipeline>."'
+            InputTemplate: !Sub '"Build for <Pipeline> failed to deploy to test stack. To view the pipeline, go to https://${AWS::Region}.console.aws.amazon.com/codepipeline/home?region=${AWS::Region}#/view/<Pipeline>."'
 
   ApprovalFailureEventRule:
     Type: AWS::Events::Rule
@@ -235,7 +235,7 @@ Resources:
           InputTransformer:
             InputPathsMap:
               Pipeline: "$.detail.pipeline"
-            InputTemplate: !Sub '"Build for ${AWS::StackName} was rejected either due to a QA failure or UAT rejection. To view the pipeline, go to https://${AWS::Region}.console.aws.amazon.com/codepipeline/home?region=${AWS::Region}#/view/<Pipeline>."'
+            InputTemplate: !Sub '"Build for <Pipeline> was rejected either due to a QA failure or UAT rejection. To view the pipeline, go to https://${AWS::Region}.console.aws.amazon.com/codepipeline/home?region=${AWS::Region}#/view/<Pipeline>."'
 
   DeployToProdFailureEventRule:
     Type: AWS::Events::Rule
@@ -262,4 +262,4 @@ Resources:
           InputTransformer:
             InputPathsMap:
               Pipeline: "$.detail.pipeline"
-            InputTemplate: !Sub '"Build for ${AWS::StackName} failed to deploy to production stack. To view the pipeline, go to https://${AWS::Region}.console.aws.amazon.com/codepipeline/home?region=${AWS::Region}#/view/<Pipeline>."'
+            InputTemplate: !Sub '"Build for <Pipeline> failed to deploy to production stack. To view the pipeline, go to https://${AWS::Region}.console.aws.amazon.com/codepipeline/home?region=${AWS::Region}#/view/<Pipeline>."'


### PR DESCRIPTION
## ESU-675: Bugfix pipeline name

349a713525fe1f473fc8a801e050c7ed7a03ee7d

Changed references to the stack name to use the given pipeline name. This is not as friendly a name, but is also a little more accurate and less dependent on stack naming conventions.

An extra, unrelated change is to the default desired count of services to run for the image service. We are currently in a pattern of only ever using one, so the default was going against our current pattern.