### PR TITLE
MEL-89: Create infrastructure for new static website assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ aws cloudformation deploy \
   --template-file deploy/cloudformation/static-host-pipeline.yml \
   --tags ProjectName=mellon \
   --parameter-overrides OAuth=my_oauth_key Approvers=me@myhost.com \
-    SourceRepoOwner=ndlib SourceRepoName=image-viewer \
+    SourceRepoOwner=ndlib SourceRepoName=image-viewer BuildScriptsDir='build' BuildOutputDir='dist' \
     TestStackName=mellon-image-webcomponent-test ProdStackName=mellon-image-webcomponent-prod \
     NameTag='testaccount-mellonimagewebcomponentpipeline' ContactTag='me@myhost.com' OwnerTag='myid'
 ```

--- a/README.md
+++ b/README.md
@@ -69,16 +69,25 @@ aws cloudformation deploy \
 ```console
 aws cloudformation deploy \
   --stack-name mellon-image-webcomponent-dev \
-  --template-file deploy/cloudformation/iiif-webcomponent.yml \
+  --template-file deploy/cloudformation/static-host.yml \
   --tags ProjectName=mellon \
   --parameter-overrides NameTag='testaccount-mellonimagewebcomponent-dev' ContactTag='me@myhost.com' OwnerTag='myid'
+```
+
+### Main Website stack
+```console
+aws cloudformation deploy \
+  --stack-name mellon-website-dev \
+  --template-file deploy/cloudformation/static-host.yml \
+  --tags ProjectName=mellon \
+  --parameter-overrides NameTag='testaccount-mellonwebsite-dev' ContactTag='me@myhost.com' OwnerTag='myid'
 ```
 
 ## Deploy CI/CD
 Before you begin see https://developer.github.com/v3/auth/#via-oauth-tokens for how to generate an OAuth token for use with these pipelines.
 
 ### IIIF Image Service Pipeline
-This will deploy to test, then to production, so it expects two different image-viewer stacks to exist, ex: "mellon-image-webcomponent-test" and "mellon-image-webcomponent-prod". If custom stack names were used for the image-viewer stacks, you'll need to override the default parameter store paths for TestDeployBucket, TestURL, ProdDeployBucket, and ProdURL.
+This will deploy to test, then to production, so it expects two different image-service stacks to exist, ex: "mellon-image-service-test" and "mellon-image-service-prod". If custom stack names were used for the image-service stacks, you'll need to override the default parameters for IIIFProdServiceStackName and IIIFTestServiceStackName.
 
 ```console
 aws cloudformation deploy \
@@ -97,12 +106,26 @@ This will deploy to test, then to production, so it expects two different image-
 aws cloudformation deploy \
   --capabilities CAPABILITY_IAM \
   --stack-name mellon-image-webcomponent-pipeline \
-  --template-file deploy/cloudformation/iiif-webcomponent-pipeline.yml \
+  --template-file deploy/cloudformation/static-host-pipeline.yml \
   --tags ProjectName=mellon \
   --parameter-overrides OAuth=my_oauth_key Approvers=me@myhost.com \
+    SourceRepoOwner=ndlib SourceRepoName=image-viewer \
     NameTag='testaccount-mellonimagewebcomponentpipeline' ContactTag='me@myhost.com' OwnerTag='myid'
 ```
 
+### Main Website Pipeline
+This will deploy to test, then to production, so it expects two different image-viewer stacks to exist, ex: "mellon-image-webcomponent-test" and "mellon-image-webcomponent-prod". If custom stack names were used for the image-viewer stacks, you'll need to override the default parameter store paths for TestDeployBucket, TestURL, ProdDeployBucket, and ProdURL.
+
+```console
+aws cloudformation deploy \
+  --capabilities CAPABILITY_IAM \
+  --stack-name mellon-image-webcomponent-pipeline \
+  --template-file deploy/cloudformation/static-host-pipeline.yml \
+  --tags ProjectName=mellon \
+  --parameter-overrides OAuth=my_oauth_key Approvers=me@myhost.com \
+    SourceRepoOwner=ndlib SourceRepoName=mellon-website \
+    NameTag='testaccount-mellonimagewebcomponentpipeline' ContactTag='me@myhost.com' OwnerTag='myid'
+```
 
 #### Approval message
 Once the pipeline reaches the UAT step, it will send an email to the approvers list and wait until it's either approved or rejected. Here's an example of the message.

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ aws cloudformation deploy \
 ```
 
 ### IIIF Image Viewer Pipeline
-This will deploy to test, then to production, so it expects two different image-viewer stacks to exist, ex: "mellon-image-webcomponent-test" and "mellon-image-webcomponent-prod". If custom stack names were used for the image-viewer stacks, you'll need to override the default parameter store paths for TestDeployBucket, TestURL, ProdDeployBucket, and ProdURL.
+This will deploy to test, then to production, so it expects two different image-viewer stacks to exist, ex: "mellon-image-webcomponent-test" and "mellon-image-webcomponent-prod".
 
 ```console
 aws cloudformation deploy \
@@ -110,21 +110,23 @@ aws cloudformation deploy \
   --tags ProjectName=mellon \
   --parameter-overrides OAuth=my_oauth_key Approvers=me@myhost.com \
     SourceRepoOwner=ndlib SourceRepoName=image-viewer \
+    TestStackName=mellon-image-webcomponent-test ProdStackName=mellon-image-webcomponent-prod \
     NameTag='testaccount-mellonimagewebcomponentpipeline' ContactTag='me@myhost.com' OwnerTag='myid'
 ```
 
-### Main Website Pipeline
-This will deploy to test, then to production, so it expects two different image-viewer stacks to exist, ex: "mellon-image-webcomponent-test" and "mellon-image-webcomponent-prod". If custom stack names were used for the image-viewer stacks, you'll need to override the default parameter store paths for TestDeployBucket, TestURL, ProdDeployBucket, and ProdURL.
+### Website Pipeline
+This will deploy to test, then to production, so it expects two different website stacks to exist, ex: "mellon-website-test" and "mellon-website-prod".
 
 ```console
 aws cloudformation deploy \
   --capabilities CAPABILITY_IAM \
-  --stack-name mellon-image-webcomponent-pipeline \
+  --stack-name mellon-website-pipeline \
   --template-file deploy/cloudformation/static-host-pipeline.yml \
   --tags ProjectName=mellon \
   --parameter-overrides OAuth=my_oauth_key Approvers=me@myhost.com \
     SourceRepoOwner=ndlib SourceRepoName=mellon-website \
-    NameTag='testaccount-mellonimagewebcomponentpipeline' ContactTag='me@myhost.com' OwnerTag='myid'
+    TestStackName=mellon-website-test ProdStackName=mellon-website-prod \
+    NameTag='testaccount-mellonwebsitepipeline' ContactTag='me@myhost.com' OwnerTag='myid'
 ```
 
 #### Approval message
@@ -152,6 +154,15 @@ aws cloudformation deploy \
   --template-file deploy/cloudformation/pipeline-monitoring.yml \
   --tags ProjectName=mellon \
   --parameter-overrides PipelineStackName=mellon-image-webcomponent-pipeline Receivers=me@myhost.com
+```
+
+Here's an example of adding monitoring to the website-pipeline
+```console
+aws cloudformation deploy \
+  --stack-name mellon-website-pipeline-monitoring \
+  --template-file deploy/cloudformation/pipeline-monitoring.yml \
+  --tags ProjectName=mellon \
+  --parameter-overrides PipelineStackName=mellon-website-pipeline Receivers=me@myhost.com
 ```
 
 Here's an example of adding monitoring to the image-service-pipeline

--- a/deploy/cloudformation/static-host-pipeline.yml
+++ b/deploy/cloudformation/static-host-pipeline.yml
@@ -33,6 +33,11 @@ Parameters:
     Description: The location of all codebuild scripts, relative to the root of the project. Expects to find the following scripts
       install.sh, pre_build.sh, build.sh, and post_build.sh.
 
+  BuildOutputDir:
+    Type: String
+    Default: build
+    Description: The location of the final build artifacts for the project. Everything in this directory will get copied to the target bucket.
+
   NameTag:
     Type: String
     Description: The value to add for the "Name" tag. This should share a value with all stacks associated with this project
@@ -131,29 +136,29 @@ Resources:
       TimeoutInMinutes: 10
       Source:
         Type: CODEPIPELINE
-        BuildSpec: |
+        BuildSpec: !Sub |
           version: 0.2
 
           phases:
             install:
               commands:
                 - echo Install started on `date`
-                - chmod -R 755 $BUILD_SCRIPTS/*
-                - $BUILD_SCRIPTS/install.sh
+                - chmod -R 755 ${BuildScriptsDir}/*
+                - ${BuildScriptsDir}/install.sh
             pre_build:
               commands:
                 - echo Pre-build started on `date`
-                - $BUILD_SCRIPTS/pre_build.sh
+                - ${BuildScriptsDir}/pre_build.sh
             build:
               commands:
                 - echo Build started on `date`
-                - $BUILD_SCRIPTS/build.sh
+                - ${BuildScriptsDir}/build.sh
             post_build:
               commands:
                 - echo Beginning post build on `date`
-                - $BUILD_SCRIPTS/post_build.sh
+                - ${BuildScriptsDir}/post_build.sh
           artifacts:
-            base-directory: build
+            base-directory: ${BuildOutputDir}
             files:
               - '**/*'
 
@@ -170,8 +175,6 @@ Resources:
             Value: !Ref AWS::AccountId
           - Name: PIPELINE_NAME
             Value: !Ref NameTag
-          - Name: BUILD_SCRIPTS
-            Value: !Ref BuildScriptsDir
       Tags:
         - Key: Name
           Value: !Ref NameTag

--- a/deploy/cloudformation/static-host-pipeline.yml
+++ b/deploy/cloudformation/static-host-pipeline.yml
@@ -27,6 +27,12 @@ Parameters:
     Default: master
     Description: The name of the branch to watch for continuous deployment
 
+  BuildScriptsDir:
+    Type: String
+    Default: scripts/codebuild
+    Description: The location of all codebuild scripts, relative to the root of the project. Expects to find the following scripts
+      install.sh, pre_build.sh, build.sh, and post_build.sh.
+
   NameTag:
     Type: String
     Description: The value to add for the "Name" tag. This should share a value with all stacks associated with this project
@@ -132,20 +138,20 @@ Resources:
             install:
               commands:
                 - echo Install started on `date`
-                - chmod -R 755 scripts/build/*
-                - ./scripts/build/install.sh
+                - chmod -R 755 $BUILD_SCRIPTS/*
+                - $BUILD_SCRIPTS/install.sh
             pre_build:
               commands:
                 - echo Pre-build started on `date`
-                - ./scripts/build/pre_build.sh
+                - $BUILD_SCRIPTS/pre_build.sh
             build:
               commands:
                 - echo Build started on `date`
-                - ./scripts/build/build.sh
+                - $BUILD_SCRIPTS/build.sh
             post_build:
               commands:
                 - echo Beginning post build on `date`
-                - ./scripts/build/post_build.sh
+                - $BUILD_SCRIPTS/post_build.sh
           artifacts:
             base-directory: build
             files:
@@ -164,6 +170,8 @@ Resources:
             Value: !Ref AWS::AccountId
           - Name: PIPELINE_NAME
             Value: !Ref NameTag
+          - Name: BUILD_SCRIPTS
+            Value: !Ref BuildScriptsDir
       Tags:
         - Key: Name
           Value: !Ref NameTag

--- a/deploy/cloudformation/static-host-pipeline.yml
+++ b/deploy/cloudformation/static-host-pipeline.yml
@@ -5,7 +5,7 @@ Description: >
   - Creates a CodePipeline that has a specific CodeBuild associated,
   which on a merge to master will build the project, push it to
   a bucket, and deploy it to a test stack.
-  - The scripts that are used at each phase of the CodeBuild are stored in ndlib/image-viewer rather than
+  - The scripts that are used at each phase of the CodeBuild are stored in the source repo rather than
   this file.
 
 
@@ -13,6 +13,14 @@ Parameters:
   Approvers:
     Type: String
     Description: An e-mail address of someone who can approve test environment
+
+  SourceRepoOwner:
+    Type: String
+    Description: The owner of the repository in Github
+
+  SourceRepoName:
+    Type: String
+    Description: The name of the repository in Github
 
   CDBranchName:
     Type: String
@@ -38,25 +46,13 @@ Parameters:
     NoEcho: true
     Description: The OAuth Token Value to connect CodePipeline to GitHub. Passed in at Runtime.
 
-  TestDeployBucket:
-    Type: 'AWS::SSM::Parameter::Value<String>'
-    Description: The path to the param that stores the test deployment bucket.
-    Default: "/all/stacks/mellon-image-webcomponent-test/bucket"
+  ProdStackName:
+    Type: String
+    Description: The name of the CloudFormation stack that created the production static host
 
-  TestURL:
-    Type: 'AWS::SSM::Parameter::Value<String>'
-    Description: The path to the param that stores the test URL.
-    Default: "/all/stacks/mellon-image-webcomponent-test/url"
-
-  ProdDeployBucket:
-    Type: 'AWS::SSM::Parameter::Value<String>'
-    Description: The path to the param that stores the test deployment bucket.
-    Default: "/all/stacks/mellon-image-webcomponent-prod/bucket"
-
-  ProdURL:
-    Type: 'AWS::SSM::Parameter::Value<String>'
-    Description: The path to the param that stores the test URL.
-    Default: "/all/stacks/mellon-image-webcomponent-prod/url"
+  TestStackName:
+    Type: String
+    Description: The name of the CloudFormation stack that created the test static host
 
 Outputs:
 
@@ -123,8 +119,8 @@ Resources:
   CodeBuilder:
     Type: 'AWS::CodeBuild::Project'
     Properties:
-      Name: mellon_iiif_webcomponent_codepipeline_builder
-      Description: 'Build Image Viewer Webcomponent from GitHub for CodePipeline'
+      Name: !Sub '${AWS::StackName}-CodeBuilder'
+      Description: 'Builds source web component from GitHub'
       ServiceRole: !Ref CodeBuildRole
       TimeoutInMinutes: 10
       Source:
@@ -136,22 +132,22 @@ Resources:
             install:
               commands:
                 - echo Install started on `date`
-                - chmod -R 755 build/*
-                - ./build/install.sh
+                - chmod -R 755 scripts/build/*
+                - ./scripts/build/install.sh
             pre_build:
               commands:
                 - echo Pre-build started on `date`
-                - ./build/pre_build.sh
+                - ./scripts/build/pre_build.sh
             build:
               commands:
                 - echo Build started on `date`
-                - ./build/build.sh
+                - ./scripts/build/build.sh
             post_build:
               commands:
                 - echo Beginning post build on `date`
-                - ./build/post_build.sh
+                - ./scripts/build/post_build.sh
           artifacts:
-            base-directory: dist
+            base-directory: build
             files:
               - '**/*'
 
@@ -168,6 +164,13 @@ Resources:
             Value: !Ref AWS::AccountId
           - Name: PIPELINE_NAME
             Value: !Ref NameTag
+      Tags:
+        - Key: Name
+          Value: !Ref NameTag
+        - Key: Owner
+          Value: !Ref OwnerTag
+        - Key: Contact
+          Value: !Ref ContactTag
 
   CodeTestDeployRole:
     Type: AWS::IAM::Role
@@ -223,8 +226,14 @@ Resources:
                   - s3:DeleteObject
                   - s3:ListBucket
                 Resource:
-                  - !Sub "arn:aws:s3:::${TestDeployBucket}"
-                  - !Sub "arn:aws:s3:::${TestDeployBucket}/*"
+                  - Fn::Sub:
+                    - "arn:aws:s3:::${DeployBucket}"
+                    - DeployBucket:
+                        Fn::ImportValue: !Join [':', [!Ref TestStackName, 'BucketName']]
+                  - Fn::Sub:
+                    - "arn:aws:s3:::${DeployBucket}/*"
+                    - DeployBucket:
+                        Fn::ImportValue: !Join [':', [!Ref TestStackName, 'BucketName']]
 
   CodeProdDeployRole:
     Type: AWS::IAM::Role
@@ -280,14 +289,20 @@ Resources:
                   - s3:DeleteObject
                   - s3:ListBucket
                 Resource:
-                  - !Sub "arn:aws:s3:::${ProdDeployBucket}"
-                  - !Sub "arn:aws:s3:::${ProdDeployBucket}/*"
+                  - Fn::Sub:
+                    - "arn:aws:s3:::${DeployBucket}"
+                    - DeployBucket:
+                        Fn::ImportValue: !Join [':', [!Ref ProdStackName, 'BucketName']]
+                  - Fn::Sub:
+                    - "arn:aws:s3:::${DeployBucket}/*"
+                    - DeployBucket:
+                        Fn::ImportValue: !Join [':', [!Ref ProdStackName, 'BucketName']]
 
   CodeTestDeployer:
     Type: 'AWS::CodeBuild::Project'
     Properties:
-      Name: mellon_iiif_webcomponent_codepipeline_test_deployer
-      Description: 'Build Image Viewer Webcomponent from GitHub for CodePipeline'
+      Name: !Sub '${AWS::StackName}-CodeTestDeployer'
+      Description: 'Deploys built source web component to test bucket'
       ServiceRole: !Ref CodeTestDeployRole
       TimeoutInMinutes: 10
       Source:
@@ -316,13 +331,21 @@ Resources:
         Image: aws/codebuild/ubuntu-base:14.04
         EnvironmentVariables:
           - Name: DEST_BUCKET
-            Value: !Ref TestDeployBucket
+            Value:
+              Fn::ImportValue: !Join [':', [!Ref TestStackName, 'BucketName']]
+      Tags:
+        - Key: Name
+          Value: !Ref NameTag
+        - Key: Owner
+          Value: !Ref OwnerTag
+        - Key: Contact
+          Value: !Ref ContactTag
 
   CodeProdDeployer:
     Type: 'AWS::CodeBuild::Project'
     Properties:
-      Name: mellon_iiif_webcomponent_codepipeline_prod_deployer
-      Description: 'Build Image Viewer Webcomponent from GitHub for CodePipeline'
+      Name: !Sub '${AWS::StackName}-CodeProdDeployer'
+      Description: 'Deploys built source web component to production bucket'
       ServiceRole: !Ref CodeProdDeployRole
       TimeoutInMinutes: 10
       Source:
@@ -352,7 +375,15 @@ Resources:
         Image: aws/codebuild/ubuntu-base:14.04
         EnvironmentVariables:
           - Name: DEST_BUCKET
-            Value: !Ref ProdDeployBucket
+            Value:
+              Fn::ImportValue: !Join [':', [!Ref ProdStackName, 'BucketName']]
+      Tags:
+        - Key: Name
+          Value: !Ref NameTag
+        - Key: Owner
+          Value: !Ref OwnerTag
+        - Key: Contact
+          Value: !Ref ContactTag
 
   CodeS3Bucket:
     Type: AWS::S3::Bucket
@@ -456,8 +487,8 @@ Resources:
                 Provider: GitHub
                 Version: "1"
               Configuration:
-                Owner: ndlib
-                Repo: image-viewer
+                Owner: !Ref SourceRepoOwner
+                Repo: !Ref SourceRepoName
                 Branch: !Ref CDBranchName
                 OAuthToken: !Ref OAuth
               OutputArtifacts:
@@ -506,7 +537,13 @@ Resources:
                 Version: "1"
               Configuration:
                 NotificationArn: !Ref ApproversTopic
-                CustomData: !Sub "You can review these changes at https://${TestURL}. Once approved, this will be deployed to https://${ProdURL}."
+                CustomData:
+                  Fn::Sub:
+                    - "You can review these changes at https://${TestURL}. Once approved, this will be deployed to https://${ProdURL}."
+                    - TestURL:
+                        Fn::ImportValue: !Join [':', [!Ref TestStackName, 'URL']]
+                      ProdURL:
+                        Fn::ImportValue: !Join [':', [!Ref ProdStackName, 'URL']]
 
         -
           Name: DeployToProduction

--- a/deploy/cloudformation/static-host.yml
+++ b/deploy/cloudformation/static-host.yml
@@ -2,7 +2,7 @@
 AWSTemplateFormatVersion: '2010-09-09'
 
 
-Description: 'Static host for IIIF webcomponents'
+Description: 'Static host for webcomponents and single-page applications'
 
 
 Parameters:
@@ -35,11 +35,21 @@ Parameters:
       - prod
     ConstraintDescription: must specify prod or dev.
 
+  NameTag:
+    Type: String
+    Description: The value to add for the "Name" tag. This should share a value with all stacks associated with this project
+    AllowedPattern: ".+-.+-(dev|prod|prep)(-.+)*"
+    ConstraintDescription: "Name should match the pattern [infra]-{service}-[env]-{etc}. Ex: libnd-myservice-dev-myname"
+
+  OwnerTag:
+    Type: String
+    Description: The value to add for the "Owner" tag. This should be the individual that owns or created this stack.
+
+  ContactTag:
+    Type: String
+    Description: The value to add for the "Contact" tag. This should be an email or phone of someone to contact for information about this stack
+
 Mappings:
-  # Cache settings to use for each environment.
-  # Note: Our current pipeline's deploy cannot do an atomic cutover when deploying a new version to production.
-  # It's best to make sure that the DefaultTTL in production covers the gap between the delete->copy commands.
-  # See CodeProdDeployer within https://github.com/ndlib/mellon-blueprints/blob/master/deploy/cloudformation/iiif-webcomponent-pipeline.yml
   CacheSettings:
     dev:
       DefaultTTL: 0
@@ -61,34 +71,29 @@ Outputs:
   BucketName:
     Description: Name of S3 bucket to hold website content
     Value: !Ref Bucket
+    Export:
+      Name: !Join [ ':', [ !Ref 'AWS::StackName', 'BucketName']]
 
-  CNAME:
-    Description: Website CNAME target
+  URL:
+    Description: The FQDN if one is given, otherwise the cloudfront distribution domain name.
+    Value: !If
+      - NoFQDN
+      - !GetAtt Distribution.DomainName
+      - !Ref FQDN
+    Export:
+      Name: !Join [ ':', [ !Ref 'AWS::StackName', 'URL']]
+
+  DistributionDomainName:
+    Description: The cloudfront distribution domain name.
     Value: !GetAtt Distribution.DomainName
 
 Resources:
-
-  BucketParameter:
-    Type: AWS::SSM::Parameter
-    Properties:
-      Type: String
-      Name: !Sub "/all/stacks/${AWS::StackName}/bucket"
-      Value: !Ref Bucket
-      Description: The name of the bucket that will serve the component files
-
-  URLParameter:
-    Type: AWS::SSM::Parameter
-    Properties:
-      Type: String
-      Name: !Sub "/all/stacks/${AWS::StackName}/url"
-      Value: !GetAtt Distribution.DomainName
-      Description: The URL endpoint for this component
 
   OriginAccessIdentity:
     Type: AWS::CloudFront::CloudFrontOriginAccessIdentity
     Properties:
       CloudFrontOriginAccessIdentityConfig:
-        Comment: IIIF Web Component Origin Access Identity
+        Comment: !Sub Static assets in ${AWS::StackName}
 
   Bucket:
     Type: AWS::S3::Bucket
@@ -98,8 +103,15 @@ Resources:
           Fn::ImportValue: !Join [':', [!Ref InfrastructureStackName, 'LogBucket']]
         LogFilePrefix: !If
           - NoFQDN
-          - s3/iiif-webcomponent/
+          - !Sub s3/${AWS::StackName}/
           - !Sub s3/${FQDN}/
+      Tags:
+        - Key: Name
+          Value: !Ref NameTag
+        - Key: Owner
+          Value: !Ref OwnerTag
+        - Key: Contact
+          Value: !Ref ContactTag
 
   BucketPolicy:
     Type: AWS::S3::BucketPolicy
@@ -173,6 +185,13 @@ Resources:
               - !Ref AWS::URLSuffix
           Prefix: !If
             - NoFQDN
-            - web/iiif-webcomponent/
+            - !Sub web/${AWS::StackName}/
             - !Sub web/${FQDN}/
           IncludeCookies: true
+      Tags:
+        - Key: Name
+          Value: !Ref NameTag
+        - Key: Owner
+          Value: !Ref OwnerTag
+        - Key: Contact
+          Value: !Ref ContactTag


### PR DESCRIPTION
## MEL-89: Create infrastructure for new static website assets

bf4c2b6dbcb5b3375afdc39580b2dc79d5475a53

There are now two components that fall into the static host pattern: the iiif web component, and the mellon-website. Changed the iiif-web-component templates (including the pipeline) to be a bit more generic so that we can reuse them for any components that require static hosting. Changes related to this:
- Parameterized the pipeline to allow for specifying the repo to watch, the source scripts for the build process, and the directory to copy built artifacts from
- Changed the parameters for the pipeline to use stack names to find the exports for the target buckets and urls. This is to reduce the number of parameters that need to be overridden. It unfortunately creates an export dependency, so if this causes problems we'll have to change. Would have liked to use https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/dynamic-references.html for this, but the version requirement would make this difficult.
- Updated the README to include examples of deploying the iiif web component and the website by reusing these new, more generic, templates
- Had to give several resources within the pipeline better names based on the stack name in order to distinguish it from other pipelines that use the same template

Other Changes:
- We're moving to using /build as the target directory for build scripts (was /dist), and /scripts/build as the directory to find build scripts (was /build). Changed the CodeBuilder to use this new pattern
- Made an audit pass over our Tags and found several resources that needed name/owner/contact tags
- Added better descriptions to several resources