### PR TITLE
MEL-70: Add protocol to specs

### DIFF
--- a/deploy/cloudformation/iiif-service-pipeline.yml
+++ b/deploy/cloudformation/iiif-service-pipeline.yml
@@ -158,7 +158,7 @@ Resources:
               commands:
                 - echo Build started on `date`
                 - |
-                  printf '{"name": "image_server.test","values": [{"key": "image-server-host","value": "%s:8182","description": "This is the hostname to my environment","type": "text","enabled": true}],"_postman_variable_scope": "environment","_postman_exported_at": "2018-08-29T20:49:10.416Z","_postman_exported_using": "Postman/6.2.5"}' $TESTING_URL >> test_env.json
+                  printf '{"name": "image_server.test","values": [{"key": "image-server-host","value": "%s:8182"}, {"key": "image-server-protocol","value": "https"}],"_postman_variable_scope": "environment"}' $TESTING_URL >> test_env.json
                 - cat test_env.json
                 - newman run spec/image-server.postman_collection.json -e test_env.json
             post_build:

--- a/deploy/cloudformation/iiif-service.yml
+++ b/deploy/cloudformation/iiif-service.yml
@@ -178,16 +178,21 @@ Resources:
   TargetGroup:
     Type: AWS::ElasticLoadBalancingV2::TargetGroup
     Properties:
-      # It takes on average almost 60 seconds to start this in ECS
-      HealthCheckIntervalSeconds: 30
       HealthCheckPath: /
       HealthCheckProtocol: HTTP
+      # It takes on average almost 60 seconds to start this in ECS
+      HealthCheckIntervalSeconds: 30
       HealthCheckTimeoutSeconds: 10
-      HealthyThresholdCount: 4
+      HealthyThresholdCount: 2
+      UnhealthyThresholdCount: 3
+      TargetGroupAttributes:
+        # Under no load, it takes less than 2 seconds for the Cantaloupe container to stop.
+        # Giving 30s as a reasonable starting point
+        - Key: deregistration_delay.timeout_seconds
+          Value: '30'
       TargetType: ip
       Port: !Ref 'ContainerPort'
       Protocol: HTTP
-      UnhealthyThresholdCount: 3
       VpcId:
         Fn::ImportValue: !Join [':', [!Ref NetworkStackName, 'VPCID']]
       Tags:


### PR DESCRIPTION
## MEL-70: Add protocol to specs

a41c3198bd5892a3801bf1725c9a138a447d8174

The specs now require the protocol to be passed via the newman env. Updated the QA stage in the pipeline to match this change. Additionally, tweaked the target group in iiif-service.yml to allow faster registration/deregistration. This should speed up deployment times by approx 5 minutes.