### PR TITLE
ESU-733 remove unneeded parameters for tags and update README with new commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ aws cloudformation deploy \
   --capabilities CAPABILITY_IAM \
   --template-file deploy/cloudformation/network.yml \
   --stack-name mellon-network \
-  --tags ProjectName=mellon \
-  --parameter-overrides NameTag='testaccount-mellonnetwork-dev' ContactTag='me@myhost.com' OwnerTag='me'
+  --tags ProjectName=mellon Name='testaccount-mellonnetwork-dev' Contact='me@myhost.org' Owner='myid' \
+    Description='brief-description-of-purpose'
 ```
 
 TODO: Add example of exporting an existing network
@@ -39,8 +39,8 @@ aws cloudformation deploy \
   --capabilities CAPABILITY_IAM \
   --template-file deploy/cloudformation/app-infrastructure.yml \
   --stack-name mellon-app-infrastructure \
-  --tags ProjectName=mellon \
-  --parameter-overrides NameTag='testaccount-mellonappinfrastructure-dev' ContactTag='me@myhost.com' OwnerTag='me'
+  --tags ProjectName=mellon Name='testaccount-mellonappinfrastructure-dev' Contact='me@myhost.com' Owner='myid'\
+  Description='brief-description-of-purpose'
 ```
 
 ## Deploy Application Components
@@ -50,8 +50,8 @@ aws cloudformation deploy \
 aws cloudformation deploy \
   --stack-name mellon-data-broker-dev \
   --template-file deploy/cloudformation/data-broker.yml \
-  --tags ProjectName=mellon \
-  --parameter-overrides NameTag='testaccount-mellondatabroker-dev' ContactTag='me@myhost.com' OwnerTag='myid'
+  --tags ProjectName=mellon Name='testaccount-mellondatabroker-dev' Contact='me@myhost.com' Owner='myid'\
+  Description='brief-description-of-purpose'
 ```
 
 ### IIIF Image Service stack
@@ -60,8 +60,10 @@ aws cloudformation deploy \
   --capabilities CAPABILITY_IAM \
   --stack-name mellon-image-service-dev \
   --template-file deploy/cloudformation/iiif-service.yml \
-  --tags ProjectName=mellon \
-  --parameter-overrides NameTag='testaccount-mellonimageservice-dev' ContactTag='me@myhost.com' OwnerTag='myid' \
+  --tags ProjectName=mellon NameTag='testaccount-mellonimageservice-dev' \
+    ContactTag='me@myhost.com' OwnerTag='myid' \
+    Description='brief-description-of-purpose' \
+  --parameter-overrides
     ContainerCpu='1024' ContainerMemory='2048' DesiredCount=1
 ```
 
@@ -70,8 +72,9 @@ aws cloudformation deploy \
 aws cloudformation deploy \
   --stack-name mellon-image-webcomponent-dev \
   --template-file deploy/cloudformation/static-host.yml \
-  --tags ProjectName=mellon \
-  --parameter-overrides NameTag='testaccount-mellonimagewebcomponent-dev' ContactTag='me@myhost.com' OwnerTag='myid'
+  --tags ProjectName=mellon Name='testaccount-mellonimagewebcomponent-dev' \
+    Contact='me@myhost.com' Owner='myid' \
+    Description='brief-description-of-purpose'
 ```
 
 ### Main Website stack
@@ -79,8 +82,9 @@ aws cloudformation deploy \
 aws cloudformation deploy \
   --stack-name mellon-website-dev \
   --template-file deploy/cloudformation/static-host.yml \
-  --tags ProjectName=mellon \
-  --parameter-overrides NameTag='testaccount-mellonwebsite-dev' ContactTag='me@myhost.com' OwnerTag='myid'
+  --tags ProjectName=mellon Name='testaccount-mellonimagewebsite-dev' \
+    Contact='me@myhost.com' Owner='myid' \
+    Description='brief-description-of-purpose'
 ```
 
 ## Deploy CI/CD
@@ -94,9 +98,10 @@ aws cloudformation deploy \
   --capabilities CAPABILITY_IAM \
   --stack-name mellon-image-service-pipeline \
   --template-file deploy/cloudformation/iiif-service-pipeline.yml \
-  --tags ProjectName=mellon \
+  --tags ProjectName=mellon Name='testaccount-mellonimageservicepipeline' \
+    Contact='me@myhost.com' Owner='myid' \
+    Description='brief-description-of-purpose' \
   --parameter-overrides OAuth=my_oauth_key Approvers=me@myhost.com \
-    NameTag='testaccount-mellonimageservicepipeline' ContactTag='me@myhost.com' OwnerTag='myid'
 ```
 
 ### IIIF Image Viewer Pipeline
@@ -107,11 +112,12 @@ aws cloudformation deploy \
   --capabilities CAPABILITY_IAM \
   --stack-name mellon-image-webcomponent-pipeline \
   --template-file deploy/cloudformation/static-host-pipeline.yml \
-  --tags ProjectName=mellon \
+  --tags ProjectName=mellon Name='testaccount-mellonimagewebcomponentpipeline' \
+    Contact='me@myhost.com' Owner='myid' \
+    Description='brief-description-of-purpose' \
   --parameter-overrides OAuth=my_oauth_key Approvers=me@myhost.com \
     SourceRepoOwner=ndlib SourceRepoName=image-viewer BuildScriptsDir='build' BuildOutputDir='dist' \
-    TestStackName=mellon-image-webcomponent-test ProdStackName=mellon-image-webcomponent-prod \
-    NameTag='testaccount-mellonimagewebcomponentpipeline' ContactTag='me@myhost.com' OwnerTag='myid'
+    TestStackName=mellon-image-webcomponent-test ProdStackName=mellon-image-webcomponent-prod
 ```
 
 ### Website Pipeline
@@ -122,11 +128,12 @@ aws cloudformation deploy \
   --capabilities CAPABILITY_IAM \
   --stack-name mellon-website-pipeline \
   --template-file deploy/cloudformation/static-host-pipeline.yml \
-  --tags ProjectName=mellon \
+  --tags ProjectName=mellon Name='testaccount-mellonimagewebsitepipeline' \
+    Contact='me@myhost.com' Owner='myid' \
+    Description='brief-description-of-purpose' \
   --parameter-overrides OAuth=my_oauth_key Approvers=me@myhost.com \
     SourceRepoOwner=ndlib SourceRepoName=mellon-website \
-    TestStackName=mellon-website-test ProdStackName=mellon-website-prod \
-    NameTag='testaccount-mellonwebsitepipeline' ContactTag='me@myhost.com' OwnerTag='myid'
+    TestStackName=mellon-website-test ProdStackName=mellon-website-prod
 ```
 
 #### Approval message
@@ -152,7 +159,8 @@ Here's an example of adding monitoring to the image-webcomponent-pipeline
 aws cloudformation deploy \
   --stack-name mellon-image-webcomponent-pipeline-monitoring \
   --template-file deploy/cloudformation/pipeline-monitoring.yml \
-  --tags ProjectName=mellon \
+  --tags ProjectName=mellon Name='testaccount-mellonimagewebcomponentpipeline-monitoring' \
+    Contact='me@myhost.com' Owner='myid' Description='brief-description-of-purpose' \
   --parameter-overrides PipelineStackName=mellon-image-webcomponent-pipeline Receivers=me@myhost.com
 ```
 
@@ -161,7 +169,8 @@ Here's an example of adding monitoring to the website-pipeline
 aws cloudformation deploy \
   --stack-name mellon-website-pipeline-monitoring \
   --template-file deploy/cloudformation/pipeline-monitoring.yml \
-  --tags ProjectName=mellon \
+  --tags ProjectName=mellon Name='testaccount-mellonimagewebsitepipeline-monitoring' \
+    Contact='me@myhost.com' Owner='myid' Description='brief-description-of-purpose' \
   --parameter-overrides PipelineStackName=mellon-website-pipeline Receivers=me@myhost.com
 ```
 
@@ -170,7 +179,8 @@ Here's an example of adding monitoring to the image-service-pipeline
 aws cloudformation deploy \
   --stack-name mellon-image-service-pipeline-monitoring \
   --template-file deploy/cloudformation/pipeline-monitoring.yml \
-  --tags ProjectName=mellon \
+  --tags ProjectName=mellon Name='testaccount-mellonimageservicepipeline-monitoring' \
+    Contact='me@myhost.com' Owner='myid' Description='brief-description-of-purpose' \
   --parameter-overrides PipelineStackName=mellon-image-service-pipeline Receivers=me@myhost.com
 ```
 

--- a/deploy/cloudformation/app-infrastructure.yml
+++ b/deploy/cloudformation/app-infrastructure.yml
@@ -28,20 +28,6 @@ Parameters:
     Description: 'The FQDN to use for the certificate, see: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-certificatemanager-certificate.html'
     Default: '*.library.nd.edu'
 
-  NameTag:
-    Type: String
-    Description: The value to add for the "Name" tag. This should share a value with all stacks associated with this project
-    AllowedPattern: ".+-.+-(dev|prod|prep)(-.+)*"
-    ConstraintDescription: "Name should match the pattern [infra]-{service}-[env]-{etc}. Ex: libnd-myservice-dev-myname"
-
-  OwnerTag:
-    Type: String
-    Description: The value to add for the "Owner" tag. This should be the individual that owns or created this stack.
-
-  ContactTag:
-    Type: String
-    Description: The value to add for the "Contact" tag. This should be an email or phone of someone to contact for information about this stack
-
 Resources:
 
   PublicLoadBalancerSecurityGroup:
@@ -55,14 +41,6 @@ Resources:
           - CidrIp: 0.0.0.0/0
             IpProtocol: "-1"
 
-      Tags:
-        - Key: Name
-          Value: !Ref NameTag
-        - Key: Owner
-          Value: !Ref OwnerTag
-        - Key: Contact
-          Value: !Ref ContactTag
-
   IIIFSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
@@ -75,13 +53,6 @@ Resources:
           FromPort: 8182
           ToPort: 8182
           CidrIp: 0.0.0.0/0 # This may need to be changed for security purposes
-      Tags:
-        - Key: Name
-          Value: !Ref NameTag
-        - Key: Owner
-          Value: !Ref OwnerTag
-        - Key: Contact
-          Value: !Ref ContactTag
 
   ContainerCluster:
     Type: AWS::ECS::Cluster
@@ -144,13 +115,6 @@ Resources:
       DomainValidationOptions:
         - DomainName: !Ref DomainName
           ValidationDomain: !Ref DomainName
-      Tags:
-        - Key: Name
-          Value: !Ref NameTag
-        - Key: Owner
-          Value: !Ref OwnerTag
-        - Key: Contact
-          Value: !Ref ContactTag
       ValidationMethod: DNS
 
 Outputs:

--- a/deploy/cloudformation/export-existing-network.yml
+++ b/deploy/cloudformation/export-existing-network.yml
@@ -4,7 +4,7 @@ AWSTemplateFormatVersion: '2010-09-09'
 Description: >
   This CloudFormation will create the following:
 
-    - Exports for the current VPCID and SubnetIDs that exist in LibND,
+    - Exports for the current VPCID and SubnetIDs that exist in your existing account,
     with consistency for the rest of the Mellon project
 
 Parameters:
@@ -20,37 +20,23 @@ Parameters:
 
   PrivateSubnet1:
     Type: AWS::EC2::Subnet::Id
-    Description: One of the private subnets in LibND
+    Description: One of the private subnets in your existing account
     Default: ''
 
   PrivateSubnet2:
     Type: AWS::EC2::Subnet::Id
-    Description: A second of the private subnets in LibND
+    Description: A second of the private subnets in your existing account
     Default: ''
 
   PublicSubnet1:
     Type: AWS::EC2::Subnet::Id
-    Description: One of the public subnets in LibND
+    Description: One of the public subnets in your existing account
     Default: ''
 
   PublicSubnet2:
     Type: AWS::EC2::Subnet::Id
-    Description: A second of the public subnets in LibND
+    Description: A second of the public subnets in your existing account
     Default: ''
-
-  NameTag:
-    Type: String
-    Description: The value to add for the "Name" tag. This should share a value with all stacks associated with this project
-    AllowedPattern: ".+-.+-(dev|prod|prep)(-.+)*"
-    ConstraintDescription: "Name should match the pattern [infra]-{service}-[env]-{etc}. Ex: libnd-myservice-dev-myname"
-
-  OwnerTag:
-    Type: String
-    Description: The value to add for the "Owner" tag. This should be the individual that owns or created this stack.
-
-  ContactTag:
-    Type: String
-    Description: The value to add for the "Contact" tag. This should be an email or phone of someone to contact for information about this stack
 
 Resources:
   VPCIDParameter:
@@ -58,7 +44,7 @@ Resources:
     Properties:
       Type: String
       Name: /all/vpcid
-      Description: The VPCID to use for LIBND Resources
+      Description: The VPCID to use for existing resources
       Value: !Ref VPC
 
 Outputs:

--- a/deploy/cloudformation/iiif-service-ci.yml
+++ b/deploy/cloudformation/iiif-service-ci.yml
@@ -9,24 +9,11 @@ Description: >
   this file.
 
 Parameters:
-  NameTag:
-    Type: String
-    Description: The value to add for the "Name" tag. This should share a value with all stacks associated with this project
-    AllowedPattern: ".+-.+-(dev|prod|prep)(-.+)*"
-    ConstraintDescription: "Name should match the pattern [infra]-{service}-[env]-{etc}. Ex: libnd-myservice-dev-myname"
-
-  OwnerTag:
-    Type: String
-    Description: The value to add for the "Owner" tag. This should be the individual that owns or created this stack.
-
-  ContactTag:
-    Type: String
-    Description: The value to add for the "Contact" tag. This should be an email or phone of someone to contact for information about this stack
-
-  ContainerPipelineStackName:
+    ContainerPipelineStackName:
     Type: String
     Description: The name of the stack that build the CodePipeline, needed to import the repository value to ensure proper tagging
     Default: 'mellon-container-pipeline'
+
 Resources:
 
   CodeBuildRole:
@@ -108,13 +95,6 @@ Resources:
   CodeS3Bucket:
     Type: AWS::S3::Bucket
     Properties:
-      Tags:
-        - Key: Name
-          Value: !Ref NameTag
-        - Key: Owner
-          Value: !Ref OwnerTag
-        - Key: Contact
-          Value: !Ref ContactTag
       BucketEncryption:
         ServerSideEncryptionConfiguration:
           - ServerSideEncryptionByDefault:

--- a/deploy/cloudformation/iiif-service-pipeline.yml
+++ b/deploy/cloudformation/iiif-service-pipeline.yml
@@ -45,20 +45,6 @@ Parameters:
     Default: master
     Description: The name of the branch to watch for continuous deployment
 
-  NameTag:
-    Type: String
-    Description: The value to add for the "Name" tag. This should share a value with all stacks associated with this project
-    AllowedPattern: ".+-.+-(dev|prod|prep)(-.+)*"
-    ConstraintDescription: "Name should match the pattern [infra]-{service}-[env]-{etc}. Ex: libnd-myservice-dev-myname"
-
-  OwnerTag:
-    Type: String
-    Description: The value to add for the "Owner" tag. This should be the individual that owns or created this stack.
-
-  ContactTag:
-    Type: String
-    Description: The value to add for the "Contact" tag. This should be an email or phone of someone to contact for information about this stack
-
   OAuth:
     Type: String
     NoEcho: true
@@ -212,13 +198,6 @@ Resources:
   CodeS3Bucket:
     Type: AWS::S3::Bucket
     Properties:
-      Tags:
-        - Key: Name
-          Value: !Ref NameTag
-        - Key: Owner
-          Value: !Ref OwnerTag
-        - Key: Contact
-          Value: !Ref ContactTag
       BucketEncryption:
         ServerSideEncryptionConfiguration:
           - ServerSideEncryptionByDefault:

--- a/deploy/cloudformation/iiif-service.yml
+++ b/deploy/cloudformation/iiif-service.yml
@@ -71,25 +71,16 @@ Parameters:
     Type: Number
     Default: 1
     Description: How many copies of the service task to run
-  NameTag:
-    Type: String
-    Description: The value to add for the "Name" tag. This should share a value with all stacks associated with this project
-    AllowedPattern: ".+-.+-(dev|prod|prep)(-.+)*"
-    ConstraintDescription: "Name should match the pattern [infra]-{service}-[env]-{etc}. Ex: libnd-myservice-dev-myname"
-  OwnerTag:
-    Type: String
-    Description: The value to add for the "Owner" tag. This should be the individual that owns or created this stack.
-  ContactTag:
-    Type: String
-    Description: The value to add for the "Contact" tag. This should be an email or phone of someone to contact for information about this stack
 
 Outputs:
   PublicLoadBalancerDNSName:
     Description: The dns name of the load balancer
     Value: !GetAtt PublicLoadBalancer.DNSName
+
   ImageDerivativeCacheBucketName:
     Description: The name of the bucket that will be used as the source/destination for derivative images
     Value: !Ref ImageDerivativeCacheBucket
+
   ServiceName:
     Description: The Name of the created ECS Service
     Value: !Ref Service
@@ -195,13 +186,6 @@ Resources:
       Protocol: HTTP
       VpcId:
         Fn::ImportValue: !Join [':', [!Ref NetworkStackName, 'VPCID']]
-      Tags:
-        - Key: Name
-          Value: !Ref NameTag
-        - Key: Owner
-          Value: !Ref OwnerTag
-        - Key: Contact
-          Value: !Ref ContactTag
 
   PublicLoadBalancer:
     Type: AWS::ElasticLoadBalancingV2::LoadBalancer
@@ -219,13 +203,6 @@ Resources:
           Fn::ImportValue: !Join [':', [!Ref NetworkStackName, 'PublicSubnet1ID']]
         -
           Fn::ImportValue: !Join [':', [!Ref NetworkStackName, 'PublicSubnet2ID']]
-      Tags:
-        - Key: Name
-          Value: !Ref NameTag
-        - Key: Owner
-          Value: !Ref OwnerTag
-        - Key: Contact
-          Value: !Ref ContactTag
 
   PublicLoadBalancerListener:
     Type: AWS::ElasticLoadBalancingV2::Listener

--- a/deploy/cloudformation/network.yml
+++ b/deploy/cloudformation/network.yml
@@ -46,33 +46,12 @@ Parameters:
     ConstraintDescription: "Must be a valid IP CIDR range in the form x.x.x.x/x"
     Default: 10.0.3.0/24
 
-  NameTag:
-    Type: String
-    Description: The value to add for the "Name" tag. This should share a value with all stacks associated with this project
-    AllowedPattern: ".+-.+-(dev|prod|prep)(-.+)*"
-    ConstraintDescription: "Name should match the pattern [infra]-{service}-[env]-{etc}. Ex: libnd-myservice-dev-myname"
-
-  OwnerTag:
-    Type: String
-    Description: The value to add for the "Owner" tag. This should be the individual that owns or created this stack.
-
-  ContactTag:
-    Type: String
-    Description: The value to add for the "Contact" tag. This should be an email or phone of someone to contact for information about this stack
-
 Resources:
   VPC:
     Type: AWS::EC2::VPC
     Properties:
       CidrBlock: !Ref DesiredVPCCIDRBlock
       EnableDnsHostnames: true
-      Tags:
-        - Key: Name
-          Value: !Ref NameTag
-        - Key: Owner
-          Value: !Ref OwnerTag
-        - Key: Contact
-          Value: !Ref ContactTag
 
   PublicSubnet1:
     Type: AWS::EC2::Subnet
@@ -83,11 +62,7 @@ Resources:
       MapPublicIpOnLaunch: true
       Tags:
         - Key: Name
-          Value: !Ref NameTag
-        - Key: Owner
-          Value: !Ref OwnerTag
-        - Key: Contact
-          Value: !Ref ContactTag
+          Value: !Sub '${AWS::StackName}-PublicSubnet1'
 
   PublicSubnet2:
     Type: AWS::EC2::Subnet
@@ -98,11 +73,7 @@ Resources:
       MapPublicIpOnLaunch: true
       Tags:
         - Key: Name
-          Value: !Ref NameTag
-        - Key: Owner
-          Value: !Ref OwnerTag
-        - Key: Contact
-          Value: !Ref ContactTag
+          Value: !Sub '${AWS::StackName}-PublicSubnet2'
 
   PrivateSubnet1:
     Type: AWS::EC2::Subnet
@@ -113,11 +84,7 @@ Resources:
       MapPublicIpOnLaunch: false
       Tags:
         - Key: Name
-          Value: !Ref NameTag
-        - Key: Owner
-          Value: !Ref OwnerTag
-        - Key: Contact
-          Value: !Ref ContactTag
+          Value: !Sub '${AWS::StackName}-PrivateSubnet1'
 
   PrivateSubnet2:
     Type: AWS::EC2::Subnet
@@ -128,22 +95,10 @@ Resources:
       MapPublicIpOnLaunch: false
       Tags:
         - Key: Name
-          Value: !Ref NameTag
-        - Key: Owner
-          Value: !Ref OwnerTag
-        - Key: Contact
-          Value: !Ref ContactTag
+          Value: !Sub '${AWS::StackName}-PrivateSubnet2'
 
   InternetGateway:
     Type: AWS::EC2::InternetGateway
-    Properties:
-      Tags:
-        - Key: Name
-          Value: !Ref NameTag
-        - Key: Owner
-          Value: !Ref OwnerTag
-        - Key: Contact
-          Value: !Ref ContactTag
 
   InternetGatewayAttachment:
     Type: AWS::EC2::VPCGatewayAttachment
@@ -164,11 +119,7 @@ Resources:
       SubnetId: !Ref PublicSubnet1
       Tags:
         - Key: Name
-          Value: !Ref NameTag
-        - Key: Owner
-          Value: !Ref OwnerTag
-        - Key: Contact
-          Value: !Ref ContactTag
+          Value: !Sub '${AWS::StackName}-NatGateway-PublicSubnet1'
 
   NATGateway2EIP:
     Type: AWS::EC2::EIP
@@ -183,23 +134,13 @@ Resources:
       SubnetId: !Ref PublicSubnet2
       Tags:
         - Key: Name
-          Value: !Ref NameTag
-        - Key: Owner
-          Value: !Ref OwnerTag
-        - Key: Contact
-          Value: !Ref ContactTag
+          Value: !Sub '${AWS::StackName}-NatGateway-PublicSubnet2'
 
   PrivateRouteTable1:
     Type: AWS::EC2::RouteTable
     Properties:
       VpcId: !Ref VPC
-      Tags:
-        - Key: Name
-          Value: !Ref NameTag
-        - Key: Owner
-          Value: !Ref OwnerTag
-        - Key: Contact
-          Value: !Ref ContactTag
+
 
   DefaultPrivateRoute1:
     Type: AWS::EC2::Route
@@ -218,13 +159,6 @@ Resources:
     Type: AWS::EC2::RouteTable
     Properties:
       VpcId: !Ref VPC
-      Tags:
-        - Key: Name
-          Value: !Ref NameTag
-        - Key: Owner
-          Value: !Ref OwnerTag
-        - Key: Contact
-          Value: !Ref ContactTag
 
   DefaultPrivateRoute2:
     Type: AWS::EC2::Route

--- a/deploy/cloudformation/static-host-pipeline.yml
+++ b/deploy/cloudformation/static-host-pipeline.yml
@@ -38,20 +38,6 @@ Parameters:
     Default: build
     Description: The location of the final build artifacts for the project. Everything in this directory will get copied to the target bucket.
 
-  NameTag:
-    Type: String
-    Description: The value to add for the "Name" tag. This should share a value with all stacks associated with this project
-    AllowedPattern: ".+-.+(-.+)*"
-    ConstraintDescription: "Name should match the pattern [infra]-{service}{-etc}. Ex: mellon-image-webcomponent-pipeline"
-
-  OwnerTag:
-    Type: String
-    Description: The value to add for the "Owner" tag. This should be the individual that owns or created this stack.
-
-  ContactTag:
-    Type: String
-    Description: The value to add for the "Contact" tag. This should be an email or phone of someone to contact for information about this stack
-
   OAuth:
     Type: String
     NoEcho: true
@@ -173,15 +159,6 @@ Resources:
             Value: !Ref AWS::Region
           - Name: AWS_ACCOUNT_ID
             Value: !Ref AWS::AccountId
-          - Name: PIPELINE_NAME
-            Value: !Ref NameTag
-      Tags:
-        - Key: Name
-          Value: !Ref NameTag
-        - Key: Owner
-          Value: !Ref OwnerTag
-        - Key: Contact
-          Value: !Ref ContactTag
 
   CodeTestDeployRole:
     Type: AWS::IAM::Role
@@ -344,13 +321,6 @@ Resources:
           - Name: DEST_BUCKET
             Value:
               Fn::ImportValue: !Join [':', [!Ref TestStackName, 'BucketName']]
-      Tags:
-        - Key: Name
-          Value: !Ref NameTag
-        - Key: Owner
-          Value: !Ref OwnerTag
-        - Key: Contact
-          Value: !Ref ContactTag
 
   CodeProdDeployer:
     Type: 'AWS::CodeBuild::Project'
@@ -388,24 +358,10 @@ Resources:
           - Name: DEST_BUCKET
             Value:
               Fn::ImportValue: !Join [':', [!Ref ProdStackName, 'BucketName']]
-      Tags:
-        - Key: Name
-          Value: !Ref NameTag
-        - Key: Owner
-          Value: !Ref OwnerTag
-        - Key: Contact
-          Value: !Ref ContactTag
 
   CodeS3Bucket:
     Type: AWS::S3::Bucket
     Properties:
-      Tags:
-        - Key: Name
-          Value: !Ref NameTag
-        - Key: Owner
-          Value: !Ref OwnerTag
-        - Key: Contact
-          Value: !Ref ContactTag
       BucketEncryption:
         ServerSideEncryptionConfiguration:
           - ServerSideEncryptionByDefault:

--- a/deploy/cloudformation/static-host.yml
+++ b/deploy/cloudformation/static-host.yml
@@ -35,20 +35,6 @@ Parameters:
       - prod
     ConstraintDescription: must specify prod or dev.
 
-  NameTag:
-    Type: String
-    Description: The value to add for the "Name" tag. This should share a value with all stacks associated with this project
-    AllowedPattern: ".+-.+-(dev|prod|prep)(-.+)*"
-    ConstraintDescription: "Name should match the pattern [infra]-{service}-[env]-{etc}. Ex: libnd-myservice-dev-myname"
-
-  OwnerTag:
-    Type: String
-    Description: The value to add for the "Owner" tag. This should be the individual that owns or created this stack.
-
-  ContactTag:
-    Type: String
-    Description: The value to add for the "Contact" tag. This should be an email or phone of someone to contact for information about this stack
-
 Mappings:
   CacheSettings:
     dev:
@@ -105,13 +91,6 @@ Resources:
           - NoFQDN
           - !Sub s3/${AWS::StackName}/
           - !Sub s3/${FQDN}/
-      Tags:
-        - Key: Name
-          Value: !Ref NameTag
-        - Key: Owner
-          Value: !Ref OwnerTag
-        - Key: Contact
-          Value: !Ref ContactTag
 
   BucketPolicy:
     Type: AWS::S3::BucketPolicy
@@ -188,10 +167,3 @@ Resources:
             - !Sub web/${AWS::StackName}/
             - !Sub web/${FQDN}/
           IncludeCookies: true
-      Tags:
-        - Key: Name
-          Value: !Ref NameTag
-        - Key: Owner
-          Value: !Ref OwnerTag
-        - Key: Contact
-          Value: !Ref ContactTag


### PR DESCRIPTION
Because CloudFormation will propagate tags at the stack level down to the resources within the stack, we do not need to have tags at each resources, nor do we need parameters to define these tags.

This PR cleans up the parameters, resource-level tags, and updates the README to reflect this.

There is also a feature enhancement in the [network.yml](https://github.com/ndlib/mellon-blueprints/blob/ESU-733-remove-unneeded-tags/deploy/cloudformation/network.yml) stack which adds a differentiator to the Subnets and NAT Gateways by creating a custom "Name" tag for each of these resources. Without this, they appear with the same name and are difficult to tell apart within the console. 

Credit to @hanstra for suggesting that fix.