### PR TITLE
Fixed the ssm deploy issues and changed to use the correct app config path for ssm

### DIFF
--- a/deploy/cloudformation/manifest-pipeline-pipeline.yml
+++ b/deploy/cloudformation/manifest-pipeline-pipeline.yml
@@ -54,6 +54,14 @@ Parameters:
     Type: String
     Default: "mellon-data-broker"
     Description: The name of the shared data broker stack
+  AppConfigPathProd:
+    Type: String
+    Default: "/all/mellon-manifest-pipeline"
+    Description: The path the keys for parameter store should be read and written to for config
+  AppConfigPathTest:
+    Type: String
+    Default: "/all/mellon-manifest-pipeline-test"
+    Description: The path the keys for parameter store should be read and written to for config
 
 Resources:
   CodeBuildTrustRole:
@@ -152,6 +160,8 @@ Resources:
             Resource:
               - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/all/stacks/${TestStackName}/*"
               - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/all/stacks/${ProdStackName}/*"
+              - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter${AppConfigPathProd}/*"
+              - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter${AppConfigPathTest}/*"
             Effect: Allow
           - Action:
               - 'lambda:*'
@@ -286,7 +296,7 @@ Resources:
                 - >
                     echo "{
                       \"Parameters\" : {
-                        \"EnvType\" : \"test\",
+                        \"AppConfigPath: "${AppConfigPathTest}",
                         \"ImageSourceBucket\" : \"/all/stacks/${DataBrokerStackName}/publicbucket\",
                         \"ImageServerUrl\" : \"/all/stacks/${ImageServiceTestStackName}/url\"
                       },
@@ -300,7 +310,7 @@ Resources:
                 - >
                     echo "{
                       \"Parameters\" : {
-                        \"EnvType\" : \"test\",
+                        \"AppConfigPath: "${AppConfigPathProd}",
                         \"ImageSourceBucket\" : \"/all/stacks/${DataBrokerStackName}/publicbucket\",
                         \"ImageServerUrl\" : \"/all/stacks/${ImageServiceProdStackName}/url\"
                       },

--- a/deploy/cloudformation/manifest-pipeline.yml
+++ b/deploy/cloudformation/manifest-pipeline.yml
@@ -8,9 +8,6 @@ Description: >
   - Creates a bucket that the step functions use as an in process location.
   - Requires the iiif-service and mellon-data-broker pipelines to be built.  Uses ssm keys from those services
 Parameters:
-  EnvType:
-    Type: String
-    Default: 'test'
   ImageSourceBucket:
     Type: 'AWS::SSM::Parameter::Value<String>'
     Description: The name of the source bucket that the IIIF Image service will read from for its assets.
@@ -24,6 +21,9 @@ Parameters:
     Default: "mellon-app-infrastructure"
     Description: The name of the parent infrastructure/networking stack that you created. Necessary
                  to locate and reference resources created by that stack.
+  AppConfigPath:
+    Type: String
+    Description: The path to look for the application config from
 
 Outputs:
   StateMachine:
@@ -41,7 +41,7 @@ Resources:
     Type: AWS::SSM::Parameter
     Properties:
       Type: String
-      Name: !Sub "/all/stacks/${AWS::StackName}/config/image-server-base-url"
+      Name: !Sub "${AppConfigPath}/image-server-base-url"
       Value: !Ref ImageServerUrl
       Description: Image server base url
 
@@ -49,7 +49,7 @@ Resources:
     Type: AWS::SSM::Parameter
     Properties:
       Type: String
-      Name: !Sub "/all/stacks/${AWS::StackName}/config/image-server-bucket"
+      Name: !Sub "${AppConfigPath}/image-server-bucket"
       Value: !Ref ImageSourceBucket
       Description: Image server base url
 
@@ -57,7 +57,7 @@ Resources:
     Type: AWS::SSM::Parameter
     Properties:
       Type: String
-      Name: !Sub "/all/stacks/${AWS::StackName}/config/manifest-server-base-url"
+      Name: !Sub "${AppConfigPath}/manifest-server-base-url"
       Value: !GetAtt ManifestBucket.WebsiteURL
       Description: Manifest Server URL
 
@@ -65,7 +65,7 @@ Resources:
     Type: AWS::SSM::Parameter
     Properties:
       Type: String
-      Name: !Sub "/all/stacks/${AWS::StackName}/config/manifest-server-bucket"
+      Name: !Sub "${AppConfigPath}/manifest-server-bucket"
       Value: !Ref ManifestBucket
       Description: Manifest Server URL
 
@@ -73,7 +73,7 @@ Resources:
     Type: AWS::SSM::Parameter
     Properties:
       Type: String
-      Name: !Sub "/all/stacks/${AWS::StackName}/config/process-bucket"
+      Name: !Sub "${AppConfigPath}/process-bucket"
       Value: !Ref ProcessBucket
       Description: Manifest Server URL
 
@@ -127,7 +127,7 @@ Resources:
                 Action:
                   - "ssm:GetParametersByPath"
                 Effect: "Allow"
-                Resource: !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/all/stacks/${AWS::StackName}/config/"
+                Resource: !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter${AppConfigPath}/*"
         - PolicyName: ImageDerivativeCacheBucketPermissions
           PolicyDocument:
             Version: 2012-10-17
@@ -174,11 +174,11 @@ Resources:
       Handler: handler.run
       Role: !GetAtt [ LambdaExecutionRole, Arn ]
       Runtime: python3.7
-      Timeout: 25
+      Timeout: 90
       CodeUri: json-from-csv/
       Environment:
         Variables:
-          SSM_KEY_BASE: !Ref AWS::StackName
+          SSM_KEY_BASE: !Ref AppConfigPath
 
   ManifestLambdaFunction:
     Type: AWS::Serverless::Function
@@ -187,7 +187,7 @@ Resources:
       Handler: handler.run
       Role: !GetAtt [ LambdaExecutionRole, Arn ]
       Runtime: python3.7
-      Timeout: 25
+      Timeout: 90
       CodeUri: manifest-from-input-json/
 
   FinalizeLambdaFunction:
@@ -197,7 +197,7 @@ Resources:
       Handler: handler.run
       Role: !GetAtt [ LambdaExecutionRole, Arn ]
       Runtime: python3.7
-      Timeout: 25
+      Timeout: 90
       CodeUri: finalize/
       Environment:
         Variables:


### PR DESCRIPTION
These changes started because I was having trouble deploying likely because I had changed the logical name of an ssm key but not the path associated with it.  

But the main reason that they were done is that we wish to separate ssm key associated with application configuration and those that are used for stack infrastructure in the ssm path key.  So I moved my config oriented params to the config path location. 
