### PR TITLE
ses permissions

### DIFF
--- a/deploy/cloudformation/manifest-pipeline.yml
+++ b/deploy/cloudformation/manifest-pipeline.yml
@@ -165,6 +165,15 @@ Resources:
                       - !Sub "arn:aws:s3:::"
                       - !Ref ImageSourceBucket
                       - "/*"
+        - PolicyName: ManifestPipelineSesPermissions
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              -
+                Action:
+                  - "ses:SendEmail"
+                Effect: "Allow"
+                Resource: "*"
 
 
   IndexInputLambdaFunction:


### PR DESCRIPTION
Adds AWS SES permissions to lambda execution role so that the finalize lambda can send out an email notification stating the manifest pipeline job completed.  Note that there is no 'Resource' to restrict it has to be all.