### PR TITLE
Increase memory and timeout for FinalizeLambdaFunction

### DIFF
--- a/deploy/cloudformation/manifest-pipeline.yml
+++ b/deploy/cloudformation/manifest-pipeline.yml
@@ -298,7 +298,8 @@ Resources:
       Handler: handler.run
       Role: !GetAtt [ LambdaExecutionRole, Arn ]
       Runtime: python3.7
-      Timeout: 90
+      Timeout: 600
+      MemorySize: 512
       CodeUri: finalize/
       Environment:
         Variables:


### PR DESCRIPTION
Memory: 512 MB
Timeout: 10 min

To account for a large number of files that are copied at the end of the process cycle