### PR TITLE
Fix cloud front detection of default directory file.

### DIFF
--- a/deploy/cloudformation/manifest-pipeline-pipeline.yml
+++ b/deploy/cloudformation/manifest-pipeline-pipeline.yml
@@ -135,6 +135,7 @@ Resources:
               - 's3:PutBucketAcl'
               - 's3:GetBucketAcl'
               - 's3:PutBucketWebsite'
+              - 's3:DeleteBucketWebsite'
               - 's3:DeleteBucketPolicy'
               - 's3:PutBucketPolicy'
               - 's3:GetBucketPolicy'

--- a/deploy/cloudformation/manifest-pipeline-pipeline.yml
+++ b/deploy/cloudformation/manifest-pipeline-pipeline.yml
@@ -7,6 +7,11 @@ Description: >
   - Requires the iiif-service pipeline to be built.
 
 Parameters:
+  InfrastructureStackName:
+    Type: String
+    Default: mellon-app-infrastructure
+    Description: The name of the parent infrastructure/networking stack that you created. Necessary
+                 to locate and reference resources created by that stack.
   ProdStackName:
     Type: String
     Description: The name of the CloudFormation stack to use when creating the production resources
@@ -133,6 +138,12 @@ Resources:
             Resource:
               - !Sub 'arn:aws:s3:::${TestStackName}*'
               - !Sub 'arn:aws:s3:::${ProdStackName}*'
+              - Fn::Join:
+                - ""
+                -
+                  - 'arn:aws:s3:::'
+                  - Fn::ImportValue: !Join [':', [!Ref InfrastructureStackName, 'LogBucket']]
+                  - '*'
             Effect: 'Allow'
           # Allow reading from the Pipeline's artifact bucket. Required to deploy the built lambda zips
           - Action:
@@ -194,6 +205,9 @@ Resources:
               - 'cloudfront:DeleteCloudFrontOriginAccessIdentity'
               - 'cloudfront:UpdateDistribution'
               - 'cloudfront:UpdateCloudFrontOriginAccessIdentity'
+              - 'cloudfront:GetCloudFrontOriginAccessIdentityConfig'
+              - 'cloudfront:TagResource'
+              - 'cloudfront:GetDistribution'
             Resource: '*'
             Effect: Allow
       Roles:

--- a/deploy/cloudformation/manifest-pipeline-pipeline.yml
+++ b/deploy/cloudformation/manifest-pipeline-pipeline.yml
@@ -147,7 +147,7 @@ Resources:
                 -
                   - 'arn:aws:s3:::'
                   - Fn::ImportValue: !Join [':', [!Ref InfrastructureStackName, 'LogBucket']]
-                  - '*'
+                  - '/*'
             Effect: 'Allow'
           # Allow reading from the Pipeline's artifact bucket. Required to deploy the built lambda zips
           - Action:

--- a/deploy/cloudformation/manifest-pipeline-pipeline.yml
+++ b/deploy/cloudformation/manifest-pipeline-pipeline.yml
@@ -135,6 +135,9 @@ Resources:
               - 's3:PutBucketAcl'
               - 's3:GetBucketAcl'
               - 's3:PutBucketWebsite'
+              - 's3:DeleteBucketPolicy'
+              - 's3:PutBucketPolicy'
+              - 's3:GetBucketPolicy'
             Resource:
               - !Sub 'arn:aws:s3:::${TestStackName}*'
               - !Sub 'arn:aws:s3:::${ProdStackName}*'
@@ -205,9 +208,10 @@ Resources:
               - 'cloudfront:DeleteCloudFrontOriginAccessIdentity'
               - 'cloudfront:UpdateDistribution'
               - 'cloudfront:UpdateCloudFrontOriginAccessIdentity'
-              - 'cloudfront:GetCloudFrontOriginAccessIdentityConfig'
               - 'cloudfront:TagResource'
               - 'cloudfront:GetDistribution'
+              - 'cloudfront:GetCloudFrontOriginAccessIdentity'
+              - 'cloudfront:GetCloudFrontOriginAccessIdentityConfig'
             Resource: '*'
             Effect: Allow
       Roles:

--- a/deploy/cloudformation/manifest-pipeline.yml
+++ b/deploy/cloudformation/manifest-pipeline.yml
@@ -140,6 +140,21 @@ Resources:
             AllowedOrigins:
               - '*'
             MaxAge: 3000
+            
+  ManifestBucketPolicy:
+    Type: AWS::S3::BucketPolicy
+    DependsOn: OriginAccessIdentity
+    Properties:
+      Bucket: !Ref ManifestBucket
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Action:
+              - s3:GetObject
+            Resource: !Sub ${ManifestBucket.Arn}/*
+            Principal:
+              CanonicalUser: !GetAtt OriginAccessIdentity.S3CanonicalUserId
 
   OriginAccessIdentity:
     Type: AWS::CloudFront::CloudFrontOriginAccessIdentity
@@ -184,6 +199,10 @@ Resources:
             - allow-all
             - redirect-to-https
           TargetOriginId: Bucket
+          LambdaFunctionAssociations:
+            -
+              EventType: origin-request
+              LambdaFunctionARN: !Sub ${SPARedirectionLambda.Arn}:${SPARedirectionLambdaV1.Version}
         Origins:
           - Id: Bucket
             DomainName: !GetAtt ManifestBucket.DomainName
@@ -207,6 +226,58 @@ Resources:
             - !Sub web/${AWS::StackName}/
             - !Sub web/${FQDN}/
           IncludeCookies: true
+
+  LambdaEdgeBasicExecutionRole:
+    Type: "AWS::IAM::Role"
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          -
+            Effect: "Allow"
+            Principal:
+              Service:
+                - "lambda.amazonaws.com"
+                - "edgelambda.amazonaws.com"
+            Action:
+              - "sts:AssumeRole"
+      Path: "/"
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+
+  SPARedirectionLambda:
+    Type: "AWS::Lambda::Function"
+    Properties:
+      Code:
+        # This Lambda will take incoming web requests and adjust the request URI as appropriate.
+        # Any requests for assets under the "/static" path will be passed along as originally sent.
+        # Requests that start with "faviocn.ico" and "manifest.json" will also be passed
+        # To "/favicon.ico" and "manifest.json" as appropriate. If the request does not match any
+        # of these, the request will ne routed to "/index.html" for entry into the SPA
+        ZipFile: >
+          'use strict';
+          exports.handler = (event, context, callback) => {
+              var request = event.Records[0].cf.request;
+
+              if (!request.uri.endsWith('/index.json')) {
+                if (request.uri.endsWith('/')) {
+                  request.uri = request.uri + 'index.json'
+                } else {
+                  request.uri = request.uri + '/index.json'
+                }
+              }
+              return callback(null, request);
+          };
+      Description: Basic rewrite rule to send directory requests to appropriate locations in the SPA
+      Handler: index.handler
+      Role: !GetAtt LambdaEdgeBasicExecutionRole.Arn
+      Runtime: nodejs8.10
+
+  SPARedirectionLambdaV1:
+    Type: AWS::Lambda::Version
+    Properties:
+      FunctionName: !Ref SPARedirectionLambda
+      Description: Adds the rewrite rules as needed
 
   LambdaExecutionRole:
     Type: "AWS::IAM::Role"

--- a/deploy/cloudformation/manifest-pipeline.yml
+++ b/deploy/cloudformation/manifest-pipeline.yml
@@ -248,10 +248,9 @@ Resources:
     Properties:
       Code:
         # This Lambda will take incoming web requests and adjust the request URI as appropriate.
-        # Any requests for assets under the "/static" path will be passed along as originally sent.
-        # Requests that start with "faviocn.ico" and "manifest.json" will also be passed
-        # To "/favicon.ico" and "manifest.json" as appropriate. If the request does not match any
-        # of these, the request will ne routed to "/index.html" for entry into the SPA
+        # any directory that does not end with an index.json will have that appended to it.
+        # this based off of the pattern for the mellon urls which always require a directory with an
+        # index.json
         ZipFile: >
           'use strict';
           exports.handler = (event, context, callback) => {

--- a/deploy/cloudformation/manifest-pipeline.yml
+++ b/deploy/cloudformation/manifest-pipeline.yml
@@ -122,14 +122,10 @@ Resources:
   ManifestBucket:
     Type: AWS::S3::Bucket
     Properties:
-      AccessControl: PublicRead
       LoggingConfiguration:
         DestinationBucketName:
           Fn::ImportValue: !Join [':', [!Ref InfrastructureStackName, 'LogBucket']]
         LogFilePrefix: s3/data-broker/
-      WebsiteConfiguration:
-        IndexDocument: index.json
-        ErrorDocument: index.json
       CorsConfiguration:
         CorsRules:
           - Id: DefaultCorsHeader
@@ -140,7 +136,6 @@ Resources:
             AllowedOrigins:
               - '*'
             MaxAge: 3000
-            
   ManifestBucketPolicy:
     Type: AWS::S3::BucketPolicy
     DependsOn: OriginAccessIdentity
@@ -188,12 +183,15 @@ Resources:
         DefaultCacheBehavior:
           ForwardedValues:
             QueryString: false
+            Headers:
+              - "Access-Control-Request-Headers"
+              - "Access-Control-Request-Method"
+              - "Origin"
           AllowedMethods:
             - HEAD
             - GET
             - OPTIONS
           Compress: true
-          DefaultTTL: !Ref CacheSettings
           ViewerProtocolPolicy: !If
             - NoSSL
             - allow-all


### PR DESCRIPTION
To do this I added an edge lambda that detects if the index.json is not being looked for.  
As a side note this is intended to work specifically with the mellon url architectures which always have directories with an index.json file in them other file patterns are not supported. 

I updated the manifest bucket to not have a website associated with it anymore.  