### PR TITLE
Redirection and deep linking for unified site

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ aws cloudformation deploy \
 ```console
 aws cloudformation deploy \
   --stack-name mellon-website-dev \
-  --template-file deploy/cloudformation/static-host.yml \
+  --template-file deploy/cloudformation/unified-static-host.yml \
   --tags ProjectName=mellon Name='testaccount-mellonimagewebsite-dev' \
     Contact='me@myhost.com' Owner='myid' \
     Description='brief-description-of-purpose'

--- a/deploy/cloudformation/unified-static-host.yml
+++ b/deploy/cloudformation/unified-static-host.yml
@@ -1,0 +1,239 @@
+---
+AWSTemplateFormatVersion: '2010-09-09'
+
+
+Description: 'Static host for webcomponents and single-page applications'
+
+
+Parameters:
+
+  InfrastructureStackName:
+    Type: String
+    Default: mellon-app-infrastructure
+    Description: The name of the parent infrastructure/networking stack that you created. Necessary
+                 to locate and reference resources created by that stack.
+
+  AcmCertificateArn:
+    Type: String
+    Description: Arn for ACM Certificate
+    Default: ''
+
+  FQDN:
+    Type: String
+    Description: DNS name for the website to publish
+    MaxLength: 63
+    AllowedPattern: ^$|(?!-)[a-zA-Z0-9-.]{1,63}(?<!-)
+    ConstraintDescription: must be a valid DNS zone name
+    Default: ''
+
+  EnvType:
+    Type: String
+    Description: The type of environment to create.
+    Default: dev
+    AllowedValues:
+      - dev
+      - prod
+    ConstraintDescription: must specify prod or dev.
+
+Mappings:
+  CacheSettings:
+    dev:
+      DefaultTTL: 0
+    prod:
+      DefaultTTL: 86400
+
+Conditions:
+
+  NoFQDN: !Equals
+    - !Ref FQDN
+    - ''
+
+  NoSSL: !Equals
+    - !Ref AcmCertificateArn
+    - ''
+
+Outputs:
+
+  BucketName:
+    Description: Name of S3 bucket to hold website content
+    Value: !Ref Bucket
+    Export:
+      Name: !Join [ ':', [ !Ref 'AWS::StackName', 'BucketName']]
+
+  URL:
+    Description: The FQDN if one is given, otherwise the cloudfront distribution domain name.
+    Value: !If
+      - NoFQDN
+      - !GetAtt Distribution.DomainName
+      - !Ref FQDN
+    Export:
+      Name: !Join [ ':', [ !Ref 'AWS::StackName', 'URL']]
+
+  DistributionDomainName:
+    Description: The cloudfront distribution domain name.
+    Value: !GetAtt Distribution.DomainName
+
+Resources:
+
+  OriginAccessIdentity:
+    Type: AWS::CloudFront::CloudFrontOriginAccessIdentity
+    Properties:
+      CloudFrontOriginAccessIdentityConfig:
+        Comment: !Sub Static assets in ${AWS::StackName}
+
+  Bucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      LoggingConfiguration:
+        DestinationBucketName:
+          Fn::ImportValue: !Join [':', [!Ref InfrastructureStackName, 'LogBucket']]
+        LogFilePrefix: !If
+          - NoFQDN
+          - !Sub s3/${AWS::StackName}/
+          - !Sub s3/${FQDN}/
+
+  BucketPolicy:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket: !Ref Bucket
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Action:
+              - s3:GetObject
+            Resource: !Sub ${Bucket.Arn}/*
+            Principal:
+              CanonicalUser: !GetAtt OriginAccessIdentity.S3CanonicalUserId
+
+  Distribution:
+    Type: AWS::CloudFront::Distribution
+    Properties:
+      DistributionConfig:
+        Enabled: true
+        HttpVersion: http2
+        PriceClass: PriceClass_100
+        ViewerCertificate: !If
+          - NoSSL
+          - !Ref AWS::NoValue
+          - AcmCertificateArn: !Ref AcmCertificateArn
+            MinimumProtocolVersion: TLSv1.1_2016
+            SslSupportMethod: sni-only
+        Comment: !If
+          - NoFQDN
+          - !Ref AWS::NoValue
+          - !Ref FQDN
+        Aliases: !If
+          - NoFQDN
+          - !Ref AWS::NoValue
+          - - !Ref FQDN
+        DefaultRootObject: index.html
+        DefaultCacheBehavior:
+          ForwardedValues:
+            QueryString: false
+          AllowedMethods:
+            - HEAD
+            - GET
+            - OPTIONS
+          Compress: true
+          DefaultTTL: !FindInMap [CacheSettings, !Ref EnvType, "DefaultTTL"]
+          ViewerProtocolPolicy: !If
+            - NoSSL
+            - allow-all
+            - redirect-to-https
+          TargetOriginId: Bucket
+          LambdaFunctionAssociations:
+              -
+                EventType: origin-request
+                LambdaFunctionARN: !Sub ${SPARedirectionLambda.Arn}:${DefaultDirectoryIndexLambdaV1.Version}
+        Origins:
+          - Id: Bucket
+            DomainName: !GetAtt Bucket.DomainName
+            S3OriginConfig:
+              OriginAccessIdentity: !Join
+                - /
+                - - origin-access-identity
+                  - cloudfront
+                  - !Ref OriginAccessIdentity
+        Logging:
+          # This should result in "logbucketname.s3.amazonaws.com", where "logbucketname" is the value from an export
+          # named "InfrastructureStackName:LogBucket"
+          Bucket: !Join
+            - .
+            - - !ImportValue
+                Fn::Join: [':', [!Ref InfrastructureStackName, 'LogBucket']]
+              - s3
+              - !Ref AWS::URLSuffix
+          Prefix: !If
+            - NoFQDN
+            - !Sub web/${AWS::StackName}/
+            - !Sub web/${FQDN}/
+          IncludeCookies: true
+
+  LambdaEdgeBasicExecutionRole:
+    Type: "AWS::IAM::Role"
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          -
+            Effect: "Allow"
+            Principal:
+              Service:
+                - "lambda.amazonaws.com"
+                - "edgelambda.amazonaws.com"
+            Action:
+              - "sts:AssumeRole"
+      Path: "/"
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+
+  SPARedirectionLambda:
+    Type: "AWS::Lambda::Function"
+    Properties:
+      Code:
+        # This Lambda will take incoming web requests and adjust the request URI as appropriate.
+        # Any requests for assets under the "/static" path will be passed along as originally sent.
+        # Requests that start with "faviocn.ico" and "manifest.json" will also be passed
+        # To "/favicon.ico" and "manifest.json" as appropriate. If the request does not match any
+        # of these, the request will ne routed to "/index.html" for entry into the SPA
+        ZipFile: >
+          'use strict';
+          exports.handler = (event, context, callback) => {
+              var request = event.Records[0].cf.request;
+              var olduri = request.uri;
+              var rootpath = olduri.slice(0,7);
+              var fav = olduri.slice(0,12);
+              var manifest = olduri.slice(0,14);
+              var robot = olduri.slice(0,11);
+              var sitemap = olduri.slice(0,12);
+              if (rootpath == ("/static") ) {
+                request.uri = request.uri;
+                return callback(null, request);
+              } else if (fav == ("/favicon.ico") ) {
+                  request.uri = "/favicon.ico";
+                  return callback(null, request);
+              }  else if (manifest == ("/manifest.json") ) {
+                  request.uri = "/manifest.json";
+                  return callback(null, request);
+              }  else if (robot == ("/robots.txt") ) {
+                  request.uri = "/robots.txt";
+                  return callback(null, request);
+              }  else if (sitemap == ("/sitemap.xml") ) {
+                  request.uri = "/sitemap.xml";
+                  return callback(null, request);
+              }  else {
+                  request.uri = "/index.html";
+                  return callback(null, request);
+              }
+          };
+      Description: Basic rewrite rule to send directory requests to appropriate locations in the SPA
+      Handler: index.handler
+      Role: !GetAtt LambdaEdgeBasicExecutionRole.Arn
+      Runtime: nodejs8.10
+
+  DefaultDirectoryIndexLambdaV1:
+    Type: AWS::Lambda::Version
+    Properties:
+      FunctionName: !Ref SPARedirectionLambda
+      Description: Adds the rewrite rules as needed


### PR DESCRIPTION
The main site is not handling deeplinking due to the CloudFront/S3 default behavior. This PR will add a Lambda and IAM for the Lambda, allowing deeplinks to resolve as well as other known paths in the SPA.

The README has also been updated to identify that there is now a separate CloudFormation for the main Mellon website - this is done because as of now, we have not identified that we want to have the redirection behavior on other static page solutions, such as the webcomponent.