### PR TITLE
update bucket policy and add authorization header forwarding

### DIFF
--- a/deploy/cloudformation/manifest-pipeline.yml
+++ b/deploy/cloudformation/manifest-pipeline.yml
@@ -144,7 +144,15 @@ Resources:
       PolicyDocument:
         Version: '2012-10-17'
         Statement:
-          - Effect: Allow
+          -
+            Effect: Allow
+            Action:
+              - s3:GetBucketCors
+            Resource: !Sub ${ManifestBucket.Arn}
+            Principal:
+              CanonicalUser: !GetAtt OriginAccessIdentity.S3CanonicalUserId
+          -
+            Effect: Allow
             Action:
               - s3:GetObject
             Resource: !Sub ${ManifestBucket.Arn}/*
@@ -187,6 +195,7 @@ Resources:
               - "Access-Control-Request-Headers"
               - "Access-Control-Request-Method"
               - "Origin"
+              - "Authorization"
           AllowedMethods:
             - HEAD
             - GET


### PR DESCRIPTION
This code addresses the public bucket access issue for the manifest pipeline in two ways:

1. Allows the `Authorization` header to the whitelist of headers to be forwarded through the CloudFront.

1. Adds `s3:GetBucketCors` policy to the Manifest Bucket's Bucket Policy that is granted to the CloudFront to allow the CloudFront to read CORS configuration.