### PR TITLE
WIP: Add DNS to manifest pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ aws cloudformation deploy \
 TODO: Add example of exporting an existing network
 
 ### Infrastructure stack
-Note: This will require adding a DNS entry to validate the certificate created by the stack. The stack will not complete until this is done. See https://docs.aws.amazon.com/acm/latest/userguide/gs-acm-validate-dns.html.
 
 ```console
 aws cloudformation deploy \
@@ -40,6 +39,25 @@ aws cloudformation deploy \
   --template-file deploy/cloudformation/app-infrastructure.yml \
   --stack-name mellon-app-infrastructure \
   --tags ProjectName=mellon Name='testaccount-mellonappinfrastructure-dev' Contact='me@myhost.com' Owner='myid'\
+  Description='brief-description-of-purpose'
+```
+
+
+### Domain stack
+Defines a domain and creates a wildcard certificate that can be used for services built in this domain. By default, it will create a zone in Route53 for you, but this can be skipped if you're using your own DNS by overriding the CreateDNSZone parameter.
+
+A few things to note:
+1. You will likely need to do this in us-east-1 so that your ACM certificate can be used by Cloudfront (see https://aws.amazon.com/premiumsupport/knowledge-center/custom-ssl-certificate-cloudfront/).
+1. This will require adding a DNS entry to validate the certificate created by the stack. The stack will not complete until this is done. See https://docs.aws.amazon.com/acm/latest/userguide/gs-acm-validate-dns.html. If you are creating a Route53 zone in this stack, you can add a record to the new zone as soon as both the zone and cert are created by the stack.
+
+```console
+aws cloudformation deploy \
+  --capabilities CAPABILITY_IAM \
+  --region us-east-1 \
+  --template-file deploy/cloudformation/domain.yml \
+  --stack-name mellon-domain \
+  --parameter-overrides DomainName='mydomain.edu' CreateDNSZone='True' UseDNSZone='' \
+  --tags ProjectName=mellon Name='mellon-domain' Contact='me@myhost.com' Owner='myid'\
   Description='brief-description-of-purpose'
 ```
 
@@ -82,6 +100,7 @@ aws cloudformation deploy \
 aws cloudformation deploy \
   --stack-name mellon-website-dev \
   --template-file deploy/cloudformation/unified-static-host.yml \
+  --parameter-overrides SubDomain='mellon-website-dev' \
   --tags ProjectName=mellon Name='testaccount-mellonimagewebsite-dev' \
     Contact='me@myhost.com' Owner='myid' \
     Description='brief-description-of-purpose'
@@ -118,6 +137,20 @@ aws cloudformation deploy \
   --parameter-overrides OAuth=my_oauth_key Approvers=me@myhost.com \
     SourceRepoOwner=ndlib SourceRepoName=image-viewer BuildScriptsDir='build' BuildOutputDir='dist' \
     TestStackName=mellon-image-webcomponent-test ProdStackName=mellon-image-webcomponent-prod
+```
+
+# IIIF Manifest Pipeline
+This will create an AWS CodePipeline that will deploy the [manifest data pipeline](https://github.com/ndlib/mellon-manifest-pipeline).
+
+```console
+aws cloudformation deploy \
+  --capabilities CAPABILITY_NAMED_IAM \
+  --stack-name mellon-manifest-deploy-pipeline \
+  --template-file deploy/cloudformation/manifest-pipeline-pipeline.yml \
+  --tags Name='mellon-manifest-pipeline' Contact='me@myhost.com' Owner='myid' Description='Deploys the IIIF Manifest Data Pipeline.' \
+  --parameter-overrides GitHubToken=my_oauth_key Receivers=me@myhost.com \
+    TestSubDomain='mellon-manifest-test' ProdSubDomain='mellon-manifest' \
+    AppConfigPathTest='/all/mellon-manifest-test' AppConfigPathProd='/all/mellon-manifest-prod'
 ```
 
 ### Website Pipeline
@@ -182,16 +215,6 @@ aws cloudformation deploy \
   --tags ProjectName=mellon Name='testaccount-mellonimageservicepipeline-monitoring' \
     Contact='me@myhost.com' Owner='myid' Description='brief-description-of-purpose' \
   --parameter-overrides PipelineStackName=mellon-image-service-pipeline Receivers=me@myhost.com
-```
-
-How to build the Manifest Pipeline Pipleine
-```console
-aws cloudformation deploy \
-  --capabilities CAPABILITY_NAMED_IAM \
-  --stack-name mellon-manifest-pipeline \
-  --template-file deploy/cloudformation/manifest-pipeline-pipeline.yml \
-  --tags Name='mellon-manifest-pipeline' Contact='me@myhost.com' Owner='myid' Description='CF for Manifest Pipeline.' \
-  --parameter-overrides GitHubToken=ADDME! Receivers=email@email.com
 ```
 
 #### Examples of the notifications:

--- a/deploy/cloudformation/app-infrastructure.yml
+++ b/deploy/cloudformation/app-infrastructure.yml
@@ -18,16 +18,6 @@ Parameters:
     Description: The name of the parent networking stack created.
     Default: "mellon-network"
 
-  EnvironmentName:
-    Type: String
-    Description: Any value that describes where the service exists
-    Default: "dev"
-
-  DomainName:
-    Type: String
-    Description: 'The DomainName to be used for all entities to be created. All services will be built within this Domain'
-    Default: 'library.nd.edu'
-
 Resources:
 
   PublicLoadBalancerSecurityGroup:
@@ -108,22 +98,7 @@ Resources:
       RetentionInDays: 7
       LogGroupName: !Join [ '-', [ !Ref 'AWS::StackName', 'LogGroup']]
 
-  ACMCertificate:
-    Type: AWS::CertificateManager::Certificate
-    Properties:
-      DomainName: !Join [ '.', [ '*', !Ref DomainName ]]
-      DomainValidationOptions:
-        - DomainName: !Join [ '.', [ '*', !Ref DomainName ]]
-          ValidationDomain: !Join [ '.', [ '*', !Ref DomainName ]]
-      ValidationMethod: DNS
-
 Outputs:
-
-  ServiceDNSDomain:
-    Description: The DNS domain for all services.
-    Value: !Ref DomainName
-    Export:
-      Name: !Join [ ':', [ !Ref 'AWS::StackName', 'DomainName']]
 
   SharedLogGroup:
     Description: The name of the log group to use for application logs
@@ -160,9 +135,3 @@ Outputs:
     Value: !Ref LogBucket
     Export:
       Name: !Join [ ':', [ !Ref 'AWS::StackName', 'LogBucket']]
-
-  AcmArnParameter:
-    Description: The ARN of the generated certificate
-    Value: !Ref ACMCertificate
-    Export:
-      Name: !Join [ ':', [ !Ref 'AWS::StackName', 'ACMCertificateARN']]

--- a/deploy/cloudformation/domain.yml
+++ b/deploy/cloudformation/domain.yml
@@ -1,0 +1,80 @@
+---
+AWSTemplateFormatVersion: '2010-09-09'
+
+Description: >
+  Defines a domain and creates a wildcard certificate that can be used for services built in this domain.
+
+  Note: You will still have to manually create the acm validation record once the zone and certificate are created. If this
+  is a subdomain, you will need to create the ns record in your domain to forward to this zone once it's created. You can do
+  this while the stack is waiting for the cert verification, which may take some time if this is a new domain.
+
+Parameters:
+
+  DomainName:
+    Type: String
+    Description: 'The domain or sub domain to be used for all entities created'
+    Default: 'library.nd.edu'
+
+  CreateDNSZone:
+    Type: String
+    Default: 'True'
+    Description: If True, will attempt to create a Route 53 zone for this domain.
+
+  UseDNSZone:
+    Type: String
+    Default: ''
+    Description: Optional parameter to use a DNS zone if one already exists for this domain
+
+Conditions:
+
+  CreateDNS: !Equals [ !Ref CreateDNSZone, 'True' ]
+  DNSZoneGiven:
+    Fn::Not:
+      - !Equals [!Ref UseDNSZone, '']
+  DoExportDNSZone:
+    Fn::Or:
+      - Condition: DNSZoneGiven
+      - Condition: CreateDNS
+
+
+Resources:
+
+  Zone:
+    Type: "AWS::Route53::HostedZone"
+    Condition: CreateDNS
+    Properties:
+      Name: !Ref DomainName
+
+  ACMCertificate:
+    Type: AWS::CertificateManager::Certificate
+    Properties:
+      DomainName: !Join [ '.', [ '*', !Ref DomainName ]]
+      DomainValidationOptions:
+        - DomainName: !Join [ '.', [ '*', !Ref DomainName ]]
+          ValidationDomain: !Join [ '.', [ '*', !Ref DomainName ]]
+      ValidationMethod: DNS
+
+Outputs:
+
+  AcmArnParameter:
+    Description: The ARN of the generated certificate
+    Value: !Ref ACMCertificate
+    Export:
+      Name: !Join [ ':', [ !Ref 'AWS::StackName', 'ACMCertificateARN']]
+
+  Domain:
+    Description: The domain for all services.
+    Value: !Ref DomainName
+    Export:
+      Name: !Join [ ':', [ !Ref 'AWS::StackName', 'DomainName']]
+
+  Zone:
+    Description: The zone id created
+    Condition: DoExportDNSZone
+    Value: !If
+      - CreateDNS
+      - !Ref Zone
+      - !Ref UseDNSZone
+
+    Export:
+      Name: !Join [ ':', [ !Ref 'AWS::StackName', 'Zone']]

--- a/deploy/cloudformation/iiif-service.yml
+++ b/deploy/cloudformation/iiif-service.yml
@@ -11,7 +11,8 @@ Description: >
     - InfrastructureStackName:IIIFSecurityGroupID
     - InfrastructureStackName:ContainerTaskExecutionRoleArn
     - InfrastructureStackName:PublicLoadBalancerSecurityGroup
-    - InfrastructureStackName:ACMCertificateARN
+    - DomainStackName:ACMCertificateARN
+    - DomainStackName:DomainName
 
 
   Expects the following exports ftom the network stack:
@@ -31,6 +32,11 @@ Parameters:
     Type: String
     Default: "mellon-app-infrastructure"
     Description: The name of the parent infrastructure/networking stack that you created. Necessary
+                 to locate and reference resources created by that stack.
+  DomainStackName:
+    Type: String
+    Default: mellon-domain
+    Description: The name of the parent domain stack that you created. Necessary
                  to locate and reference resources created by that stack.
   ImageSourceBucket:
     Type: 'AWS::SSM::Parameter::Value<String>'
@@ -90,7 +96,7 @@ Outputs:
     Value: !Sub
         - '${SubDomain}.${ResolvedDomainName}'
         - ResolvedDomainName:
-            Fn::ImportValue: !Sub '${InfrastructureStackName}:DomainName'
+            Fn::ImportValue: !Sub '${DomainStackName}:DomainName'
     Export:
       Name: !Join [ ':', [!Ref 'AWS::StackName', 'URL']]
 
@@ -114,7 +120,7 @@ Resources:
       Value: !Sub
         - '${SubDomain}.${ResolvedDomainName}'
         - ResolvedDomainName:
-            Fn::ImportValue: !Sub '${InfrastructureStackName}:DomainName'
+            Fn::ImportValue: !Sub '${DomainStackName}:DomainName'
       Description: The URL endpoint for this component
 
   # The task definition. This is a simple metadata description of what
@@ -237,7 +243,7 @@ Resources:
       Protocol: HTTPS
       Certificates:
         - CertificateArn:
-            Fn::ImportValue: !Join [':', [!Ref InfrastructureStackName, 'ACMCertificateARN']]
+            Fn::ImportValue: !Join [':', [!Ref DomainStackName, 'ACMCertificateARN']]
       SslPolicy: ELBSecurityPolicy-2016-08
 
   LoadBalancerRule:
@@ -316,15 +322,15 @@ Resources:
       HostedZoneName: !Sub
         - '${ResolvedDomainName}.'
         - ResolvedDomainName:
-            Fn::ImportValue: !Sub '${InfrastructureStackName}:DomainName'
+            Fn::ImportValue: !Sub '${DomainStackName}:DomainName'
       Comment: !Sub
         - '${SubDomain}.${ResolvedDomainName}'
         - ResolvedDomainName:
-            Fn::ImportValue: !Sub '${InfrastructureStackName}:DomainName'
+            Fn::ImportValue: !Sub '${DomainStackName}:DomainName'
       Name: !Sub
         - '${SubDomain}.${ResolvedDomainName}'
         - ResolvedDomainName:
-            Fn::ImportValue: !Sub '${InfrastructureStackName}:DomainName'
+            Fn::ImportValue: !Sub '${DomainStackName}:DomainName'
       Type: CNAME
       TTL: '900'
       ResourceRecords:

--- a/deploy/cloudformation/manifest-pipeline-pipeline.yml
+++ b/deploy/cloudformation/manifest-pipeline-pipeline.yml
@@ -12,14 +12,35 @@ Parameters:
     Default: mellon-app-infrastructure
     Description: The name of the parent infrastructure/networking stack that you created. Necessary
                  to locate and reference resources created by that stack.
+  DomainStackName:
+    Type: String
+    Default: mellon-domain
+    Description: The name of the parent domain stack that you created. Necessary
+                 to locate and reference resources created by that stack.
   ProdStackName:
     Type: String
     Description: The name of the CloudFormation stack to use when creating the production resources
     Default: "mellon-manifest-pipeline"
+  ProdSubDomain:
+    Type: String
+    Description: Host DNS name for website without Domain
+    MaxLength: 63
+    AllowedPattern: ^$|(?!-)[a-zA-Z0-9-.]{1,63}(?<!-)
+    ConstraintDescription: Must be a valid SubDomain value.
   TestStackName:
     Type: String
     Description: The name of the CloudFormation stack to use when creating the test resources
     Default: "mellon-manifest-pipeline-test"
+  TestSubDomain:
+    Type: String
+    Description: Host DNS name for website without Domain
+    MaxLength: 63
+    AllowedPattern: ^$|(?!-)[a-zA-Z0-9-.]{1,63}(?<!-)
+    ConstraintDescription: Must be a valid SubDomain value.
+  CreateDNSRecord:
+    Type: String
+    Default: "True"
+    Description: If True, will attempt to create a Route 53 DNS record for the test and prod stacks.
   Receivers:
     Type: String
     Description: An e-mail address to send the monitoring notifications
@@ -217,6 +238,20 @@ Resources:
               - 'cloudfront:GetCloudFrontOriginAccessIdentityConfig'
             Resource: '*'
             Effect: Allow
+          # The manifest pipeline is going to create DNS records. Need to allow certain permissions for the associated zone
+          - Action:
+              - 'route53:ChangeResourceRecordSets'
+              - 'route53:ListResourceRecordSets'
+            Resource: !Sub
+              - 'arn:aws:route53:::hostedzone/${ResolvedZone}'
+              - ResolvedZone:
+                  Fn::ImportValue: !Join [':', [!Ref DomainStackName, 'Zone']]
+            Effect: Allow
+          - Action:
+              - 'route53:ListHostedZones'
+              - 'route53:GetChange'
+            Resource: '*'
+            Effect: Allow
       Roles:
         - !Ref CloudFormationTrustRole
   CodePipelineTrustRole:
@@ -329,7 +364,10 @@ Resources:
                       \"Parameters\" : {
                         \"AppConfigPath\" : \"${AppConfigPathTest}\",
                         \"ImageSourceBucket\" : \"/all/stacks/${DataBrokerStackName}/publicbucket\",
-                        \"ImageServerUrl\" : \"/all/stacks/${ImageServiceTestStackName}/url\"
+                        \"ImageServerUrl\" : \"/all/stacks/${ImageServiceTestStackName}/url\",
+                        \"SubDomain\" : \"${TestSubDomain}\",
+                        \"DomainStackName\" : \"${DomainStackName}\",
+                        \"CreateDNSRecord\" : \"${CreateDNSRecord}\"
                       },
                       \"Tags\" : {
                         \"Name\" : \"${TestStackName}\",
@@ -343,7 +381,10 @@ Resources:
                       \"Parameters\" : {
                         \"AppConfigPath\" : \"${AppConfigPathProd}\",
                         \"ImageSourceBucket\" : \"/all/stacks/${DataBrokerStackName}/publicbucket\",
-                        \"ImageServerUrl\" : \"/all/stacks/${ImageServiceProdStackName}/url\"
+                        \"ImageServerUrl\" : \"/all/stacks/${ImageServiceProdStackName}/url\",
+                        \"SubDomain\" : \"${ProdSubDomain}\",
+                        \"DomainStackName\" : \"${DomainStackName}\",
+                        \"CreateDNSRecord\" : \"${CreateDNSRecord}\"
                       },
                       \"Tags\" : {
                         \"Name\" : \"${ProdStackName}\",

--- a/deploy/cloudformation/manifest-pipeline-pipeline.yml
+++ b/deploy/cloudformation/manifest-pipeline-pipeline.yml
@@ -20,7 +20,8 @@ Parameters:
   ProdStackName:
     Type: String
     Description: The name of the CloudFormation stack to use when creating the production resources
-    Default: "mellon-manifest-pipeline"
+    Default: "mellon-manifest-prod"
+    MaxLength: 26
   ProdSubDomain:
     Type: String
     Description: Host DNS name for website without Domain
@@ -30,7 +31,8 @@ Parameters:
   TestStackName:
     Type: String
     Description: The name of the CloudFormation stack to use when creating the test resources
-    Default: "mellon-manifest-pipeline-test"
+    Default: "mellon-manifest-test"
+    MaxLength: 26
   TestSubDomain:
     Type: String
     Description: Host DNS name for website without Domain

--- a/deploy/cloudformation/manifest-pipeline.yml
+++ b/deploy/cloudformation/manifest-pipeline.yml
@@ -13,6 +13,11 @@ Parameters:
     Default: mellon-app-infrastructure
     Description: The name of the parent infrastructure/networking stack that you created. Necessary
                  to locate and reference resources created by that stack.
+  DomainStackName:
+    Type: String
+    Default: mellon-domain
+    Description: The name of the parent domain stack that you created. Necessary
+                 to locate and reference resources created by that stack.
   ImageSourceBucket:
     Type: 'AWS::SSM::Parameter::Value<String>'
     Description: The name of the source bucket that the IIIF Image service will read from for its assets.
@@ -30,34 +35,26 @@ Parameters:
     Type: String
     Description: The path to look for the application config from
 
-  AcmCertificateArn:
-    Type: String
-    Description: Arn for ACM Certificate
-    Default: ''
-
   CacheSettings:
     Type: Number
     Description: The cache value to hold the manifests for.
     Default: 300
 
-  FQDN:
+  CreateDNSRecord:
     Type: String
-    Description: DNS name for the website to publish
+    Default: "True"
+    Description: If True, will attempt to create a Route 53 DNS record for the CloudFront.
+
+  SubDomain:
+    Type: String
+    Description: Host DNS name for website without Domain
     MaxLength: 63
     AllowedPattern: ^$|(?!-)[a-zA-Z0-9-.]{1,63}(?<!-)
-    ConstraintDescription: must be a valid DNS zone name
-    Default: ''
+    ConstraintDescription: Must be a valid SubDomain value.
 
 Conditions:
 
-  NoFQDN: !Equals
-    - !Ref FQDN
-    - ''
-
-  NoSSL: !Equals
-    - !Ref AcmCertificateArn
-    - ''
-
+  CreateDNS: !Equals [ !Ref CreateDNSRecord, 'True' ]
 
 Outputs:
   StateMachine:
@@ -68,6 +65,19 @@ Outputs:
 
   ManifestBucket:
     Value: !Ref ManifestBucket
+
+  URL:
+    Description: The combination of SubDomain and Domain
+    Value: !Sub
+        - '${SubDomain}.${ResolvedDomainName}'
+        - ResolvedDomainName:
+            Fn::ImportValue: !Sub '${DomainStackName}:DomainName'
+    Export:
+      Name: !Join [ ':', [ !Ref 'AWS::StackName', 'URL']]
+
+  DistributionDomainName:
+    Description: The cloudfront distribution domain name. Use this if creating your CNAME record via some other DNS
+    Value: !GetAtt Distribution.DomainName
 
 Resources:
 
@@ -159,6 +169,27 @@ Resources:
             Principal:
               CanonicalUser: !GetAtt OriginAccessIdentity.S3CanonicalUserId
 
+  Route53DNSCreation:
+    Type: AWS::Route53::RecordSet
+    Condition: CreateDNS
+    Properties:
+      HostedZoneName: !Sub
+        - '${ResolvedDomainName}.'
+        - ResolvedDomainName:
+            Fn::ImportValue: !Sub '${DomainStackName}:DomainName'
+      Comment: !Sub
+        - '${SubDomain}.${ResolvedDomainName}'
+        - ResolvedDomainName:
+            Fn::ImportValue: !Sub '${DomainStackName}:DomainName'
+      Name: !Sub
+        - '${SubDomain}.${ResolvedDomainName}'
+        - ResolvedDomainName:
+            Fn::ImportValue: !Sub '${DomainStackName}:DomainName'
+      Type: CNAME
+      TTL: '900'
+      ResourceRecords:
+        - !GetAtt Distribution.DomainName
+
   OriginAccessIdentity:
     Type: AWS::CloudFront::CloudFrontOriginAccessIdentity
     Properties:
@@ -167,26 +198,27 @@ Resources:
 
   Distribution:
     Type: AWS::CloudFront::Distribution
-    DependsOn: OriginAccessIdentity
+    DependsOn:
+      - OriginAccessIdentity
     Properties:
       DistributionConfig:
         Enabled: true
         HttpVersion: http2
         PriceClass: PriceClass_100
-        ViewerCertificate: !If
-          - NoSSL
-          - !Ref AWS::NoValue
-          - AcmCertificateArn: !Ref AcmCertificateArn
-            MinimumProtocolVersion: TLSv1.1_2016
-            SslSupportMethod: sni-only
-        Comment: !If
-          - NoFQDN
-          - !Ref AWS::NoValue
-          - !Ref FQDN
-        Aliases: !If
-          - NoFQDN
-          - !Ref AWS::NoValue
-          - - !Ref FQDN
+        ViewerCertificate:
+          AcmCertificateArn:
+            Fn::ImportValue: !Join [':', [!Ref DomainStackName, 'ACMCertificateARN']]
+          MinimumProtocolVersion: TLSv1.1_2016
+          SslSupportMethod: sni-only
+        Comment: !Sub
+          - '${SubDomain}.${ResolvedDomainName}'
+          - ResolvedDomainName:
+              Fn::ImportValue: !Sub '${DomainStackName}:DomainName'
+        Aliases:
+          - !Sub
+            - '${SubDomain}.${ResolvedDomainName}'
+            - ResolvedDomainName:
+                Fn::ImportValue: !Sub '${DomainStackName}:DomainName'
         DefaultRootObject: index.json
         DefaultCacheBehavior:
           ForwardedValues:
@@ -201,10 +233,7 @@ Resources:
             - GET
             - OPTIONS
           Compress: true
-          ViewerProtocolPolicy: !If
-            - NoSSL
-            - allow-all
-            - redirect-to-https
+          ViewerProtocolPolicy: redirect-to-https
           TargetOriginId: Bucket
           LambdaFunctionAssociations:
             -
@@ -228,10 +257,10 @@ Resources:
                 Fn::Join: [':', [!Ref InfrastructureStackName, 'LogBucket']]
               - s3
               - !Ref AWS::URLSuffix
-          Prefix: !If
-            - NoFQDN
-            - !Sub web/${AWS::StackName}/
-            - !Sub web/${FQDN}/
+          Prefix: !Sub
+            - 'web/${SubDomain}.${ResolvedDomainName}/'
+            - ResolvedDomainName:
+                Fn::ImportValue: !Sub '${DomainStackName}:DomainName'
           IncludeCookies: true
 
   LambdaEdgeBasicExecutionRole:

--- a/deploy/cloudformation/static-host.yml
+++ b/deploy/cloudformation/static-host.yml
@@ -12,6 +12,13 @@ Parameters:
     Default: mellon-app-infrastructure
     Description: The name of the parent infrastructure/networking stack that you created. Necessary
                  to locate and reference resources created by that stack.
+
+  DomainStackName:
+    Type: String
+    Default: mellon-domain
+    Description: The name of the parent domain stack that you created. Necessary
+                 to locate and reference resources created by that stack.
+
   CreateDNSRecord:
     Type: String
     Default: "True"
@@ -57,7 +64,7 @@ Outputs:
     Value: !Sub
         - '${SubDomain}.${ResolvedDomainName}'
         - ResolvedDomainName:
-            Fn::ImportValue: !Sub '${InfrastructureStackName}:DomainName'
+            Fn::ImportValue: !Sub '${DomainStackName}:DomainName'
     Export:
       Name: !Join [ ':', [ !Ref 'AWS::StackName', 'URL']]
 
@@ -82,7 +89,7 @@ Resources:
         LogFilePrefix: !Sub
             - 's3/${SubDomain}.${ResolvedDomainName}/'
             - ResolvedDomainName:
-                Fn::ImportValue: !Sub '${InfrastructureStackName}:DomainName'
+                Fn::ImportValue: !Sub '${DomainStackName}:DomainName'
 
   BucketPolicy:
     Type: AWS::S3::BucketPolicy
@@ -107,20 +114,20 @@ Resources:
         Enabled: true
         HttpVersion: http2
         PriceClass: PriceClass_100
-        ViewerCertificate: 
-          AcmCertificateArn: 
-              Fn::ImportValue: !Join [':', [!Ref InfrastructureStackName, 'ACMCertificateARN']]
+        ViewerCertificate:
+          AcmCertificateArn:
+              Fn::ImportValue: !Join [':', [!Ref DomainStackName, 'ACMCertificateARN']]
           MinimumProtocolVersion: TLSv1.1_2016
           SslSupportMethod: sni-only
         Comment: !Sub
             - '${SubDomain}.${ResolvedDomainName}'
             - ResolvedDomainName:
-                Fn::ImportValue: !Sub '${InfrastructureStackName}:DomainName'
-        Aliases: 
+                Fn::ImportValue: !Sub '${DomainStackName}:DomainName'
+        Aliases:
           - !Sub
               - '${SubDomain}.${ResolvedDomainName}'
               - ResolvedDomainName:
-                  Fn::ImportValue: !Sub '${InfrastructureStackName}:DomainName'
+                  Fn::ImportValue: !Sub '${DomainStackName}:DomainName'
         DefaultRootObject: index.html
         DefaultCacheBehavior:
           ForwardedValues:
@@ -154,7 +161,7 @@ Resources:
           Prefix: !Sub
                - 'web/${SubDomain}.${ResolvedDomainName}/'
                - ResolvedDomainName:
-                   Fn::ImportValue: !Sub '${InfrastructureStackName}:DomainName'
+                   Fn::ImportValue: !Sub '${DomainStackName}:DomainName'
           IncludeCookies: true
 
   Route53DNSCreation:
@@ -164,15 +171,15 @@ Resources:
       HostedZoneName: !Sub
         - '${ResolvedDomainName}.'
         - ResolvedDomainName:
-            Fn::ImportValue: !Sub '${InfrastructureStackName}:DomainName'
+            Fn::ImportValue: !Sub '${DomainStackName}:DomainName'
       Comment: !Sub
         - '${SubDomain}.${ResolvedDomainName}'
         - ResolvedDomainName:
-            Fn::ImportValue: !Sub '${InfrastructureStackName}:DomainName'
+            Fn::ImportValue: !Sub '${DomainStackName}:DomainName'
       Name: !Sub
         - '${SubDomain}.${ResolvedDomainName}'
         - ResolvedDomainName:
-            Fn::ImportValue: !Sub '${InfrastructureStackName}:DomainName'
+            Fn::ImportValue: !Sub '${DomainStackName}:DomainName'
       Type: CNAME
       TTL: '900'
       ResourceRecords:

--- a/deploy/cloudformation/unified-static-host.yml
+++ b/deploy/cloudformation/unified-static-host.yml
@@ -13,18 +13,23 @@ Parameters:
     Description: The name of the parent infrastructure/networking stack that you created. Necessary
                  to locate and reference resources created by that stack.
 
-  AcmCertificateArn:
+  DomainStackName:
     Type: String
-    Description: Arn for ACM Certificate
-    Default: ''
+    Default: mellon-domain
+    Description: The name of the parent domain stack that you created. Necessary
+                 to locate and reference resources created by that stack.
 
-  FQDN:
+  CreateDNSRecord:
     Type: String
-    Description: DNS name for the website to publish
+    Default: "True"
+    Description: If True, will attempt to create a Route 53 DNS record for the CloudFront.
+
+  SubDomain:
+    Type: String
+    Description: Host DNS name for website without Domain
     MaxLength: 63
     AllowedPattern: ^$|(?!-)[a-zA-Z0-9-.]{1,63}(?<!-)
-    ConstraintDescription: must be a valid DNS zone name
-    Default: ''
+    ConstraintDescription: Must be a valid SubDomain value.
 
   EnvType:
     Type: String
@@ -44,13 +49,7 @@ Mappings:
 
 Conditions:
 
-  NoFQDN: !Equals
-    - !Ref FQDN
-    - ''
-
-  NoSSL: !Equals
-    - !Ref AcmCertificateArn
-    - ''
+  CreateDNS: !Equals [ !Ref CreateDNSRecord, 'True' ]
 
 Outputs:
 
@@ -62,10 +61,10 @@ Outputs:
 
   URL:
     Description: The FQDN if one is given, otherwise the cloudfront distribution domain name.
-    Value: !If
-      - NoFQDN
-      - !GetAtt Distribution.DomainName
-      - !Ref FQDN
+    Value: !Sub
+        - '${SubDomain}.${ResolvedDomainName}'
+        - ResolvedDomainName:
+            Fn::ImportValue: !Sub '${DomainStackName}:DomainName'
     Export:
       Name: !Join [ ':', [ !Ref 'AWS::StackName', 'URL']]
 
@@ -87,10 +86,10 @@ Resources:
       LoggingConfiguration:
         DestinationBucketName:
           Fn::ImportValue: !Join [':', [!Ref InfrastructureStackName, 'LogBucket']]
-        LogFilePrefix: !If
-          - NoFQDN
-          - !Sub s3/${AWS::StackName}/
-          - !Sub s3/${FQDN}/
+        LogFilePrefix: !Sub
+            - 's3/${SubDomain}.${ResolvedDomainName}/'
+            - ResolvedDomainName:
+                Fn::ImportValue: !Sub '${DomainStackName}:DomainName'
 
   BucketPolicy:
     Type: AWS::S3::BucketPolicy
@@ -106,6 +105,27 @@ Resources:
             Principal:
               CanonicalUser: !GetAtt OriginAccessIdentity.S3CanonicalUserId
 
+  Route53DNSCreation:
+    Type: AWS::Route53::RecordSet
+    Condition: CreateDNS
+    Properties:
+      HostedZoneName: !Sub
+        - '${ResolvedDomainName}.'
+        - ResolvedDomainName:
+            Fn::ImportValue: !Sub '${DomainStackName}:DomainName'
+      Comment: !Sub
+        - '${SubDomain}.${ResolvedDomainName}'
+        - ResolvedDomainName:
+            Fn::ImportValue: !Sub '${DomainStackName}:DomainName'
+      Name: !Sub
+        - '${SubDomain}.${ResolvedDomainName}'
+        - ResolvedDomainName:
+            Fn::ImportValue: !Sub '${DomainStackName}:DomainName'
+      Type: CNAME
+      TTL: '900'
+      ResourceRecords:
+        - !GetAtt Distribution.DomainName
+
   Distribution:
     Type: AWS::CloudFront::Distribution
     Properties:
@@ -113,20 +133,20 @@ Resources:
         Enabled: true
         HttpVersion: http2
         PriceClass: PriceClass_100
-        ViewerCertificate: !If
-          - NoSSL
-          - !Ref AWS::NoValue
-          - AcmCertificateArn: !Ref AcmCertificateArn
-            MinimumProtocolVersion: TLSv1.1_2016
-            SslSupportMethod: sni-only
-        Comment: !If
-          - NoFQDN
-          - !Ref AWS::NoValue
-          - !Ref FQDN
-        Aliases: !If
-          - NoFQDN
-          - !Ref AWS::NoValue
-          - - !Ref FQDN
+        ViewerCertificate:
+          AcmCertificateArn:
+              Fn::ImportValue: !Join [':', [!Ref DomainStackName, 'ACMCertificateARN']]
+          MinimumProtocolVersion: TLSv1.1_2016
+          SslSupportMethod: sni-only
+        Comment: !Sub
+            - '${SubDomain}.${ResolvedDomainName}'
+            - ResolvedDomainName:
+                Fn::ImportValue: !Sub '${DomainStackName}:DomainName'
+        Aliases:
+          - !Sub
+              - '${SubDomain}.${ResolvedDomainName}'
+              - ResolvedDomainName:
+                  Fn::ImportValue: !Sub '${DomainStackName}:DomainName'
         DefaultRootObject: index.html
         DefaultCacheBehavior:
           ForwardedValues:
@@ -137,10 +157,7 @@ Resources:
             - OPTIONS
           Compress: true
           DefaultTTL: !FindInMap [CacheSettings, !Ref EnvType, "DefaultTTL"]
-          ViewerProtocolPolicy: !If
-            - NoSSL
-            - allow-all
-            - redirect-to-https
+          ViewerProtocolPolicy: redirect-to-https
           TargetOriginId: Bucket
           LambdaFunctionAssociations:
               -
@@ -164,10 +181,10 @@ Resources:
                 Fn::Join: [':', [!Ref InfrastructureStackName, 'LogBucket']]
               - s3
               - !Ref AWS::URLSuffix
-          Prefix: !If
-            - NoFQDN
-            - !Sub web/${AWS::StackName}/
-            - !Sub web/${FQDN}/
+          Prefix: !Sub
+               - 'web/${SubDomain}.${ResolvedDomainName}/'
+               - ResolvedDomainName:
+                   Fn::ImportValue: !Sub '${DomainStackName}:DomainName'
           IncludeCookies: true
 
   LambdaEdgeBasicExecutionRole:


### PR DESCRIPTION
- Separated the creation of the ACM and zone into a domain.yml. This can optionally skip the creation of the zone to only create the wildcard cert for the domain/subdomain. Note: this still assumes we’re continuing with a single wildcard cert for each subdomain for now. ACM was previously created in app-infrastructure, but this will allow for creating separate subdomains for different grouping of services, ex: *.domain.com and *.iiif.domain.com.
- Changed all of the lower level templates to pull from this new stack export for the domain name and cert arn
- TODO: Testing the pipelines with these changes