### PR TITLE
Update to IAM Permissions

### DIFF
--- a/deploy/cloudformation/app-infrastructure.yml
+++ b/deploy/cloudformation/app-infrastructure.yml
@@ -40,6 +40,10 @@ Resources:
           # Allow access to ALB from anywhere on the internet
           - CidrIp: 0.0.0.0/0
             IpProtocol: "-1"
+      SecurityGroupEgress:
+          # Explicitly allow all outgoing traffic
+          - CidrIp: 0.0.0.0/0
+            IpProtocol: "-1"
 
   IIIFSecurityGroup:
     Type: AWS::EC2::SecurityGroup
@@ -53,6 +57,12 @@ Resources:
           FromPort: 8182
           ToPort: 8182
           CidrIp: 0.0.0.0/0 # This may need to be changed for security purposes
+      SecurityGroupEgress:
+        -
+          IpProtocol: "-1"
+          FromPort: -1
+          ToPort: -1
+          CidrIp: 0.0.0.0/0 #This explicitly allows all outgoing traffic
 
   ContainerCluster:
     Type: AWS::ECS::Cluster

--- a/deploy/cloudformation/data-broker.yml
+++ b/deploy/cloudformation/data-broker.yml
@@ -64,6 +64,11 @@ Resources:
 
   PublicBucketPolicy:
     Type: AWS::S3::BucketPolicy
+    Metadata:
+      cfn_nag:
+        rules_to_suppress:
+          - id: F16
+            reason: "This is currently designed as a public bucket, so it's acceptable to have * principal"
     Properties:
       Bucket: !Ref PublicBucket
       PolicyDocument:

--- a/deploy/cloudformation/iiif-service-ci.yml
+++ b/deploy/cloudformation/iiif-service-ci.yml
@@ -18,6 +18,11 @@ Resources:
 
   CodeBuildRole:
     Type: AWS::IAM::Role
+    Metadata:
+      cfn_nag:
+        rules_to_suppress:
+          - id: F3
+            reason: "We're allowing the role to perform all log-related activities."
     Properties:
       AssumeRolePolicyDocument:
         Version: '2012-10-17'

--- a/deploy/cloudformation/iiif-service-pipeline.yml
+++ b/deploy/cloudformation/iiif-service-pipeline.yml
@@ -96,6 +96,11 @@ Resources:
     Type: AWS::ECR::Repository
 
   CodeBuildRole:
+    Metadata:
+      cfn_nag:
+        rules_to_suppress:
+          - id: F3
+            reason: "We're allowing the role to perform all log-related activities."
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
@@ -151,7 +156,7 @@ Resources:
   DockerQABuilder:
     Type: 'AWS::CodeBuild::Project'
     Properties:
-      Name: mellon_docker_newman_tests
+      Name: !Sub '${AWS::StackName}-newman-tests'
       Description: 'Run Newman Tests against Image Server'
       ServiceRole: !Ref CodeBuildRole
       TimeoutInMinutes: 10
@@ -190,7 +195,7 @@ Resources:
   DockerCodePipelineBuilder:
     Type: 'AWS::CodeBuild::Project'
     Properties:
-      Name: mellon_docker_codepipeline
+      Name: !Sub '${AWS::StackName}-docker-codepipeline'
       Description: 'Build Docker Image from GitHub for CodePipeline'
       ServiceRole: !Ref CodeBuildRole
       TimeoutInMinutes: 10
@@ -225,7 +230,7 @@ Resources:
   PostDeployDocker:
     Type: AWS::CodeBuild::Project
     Properties:
-      Name: image_server_docker_add_tag
+      Name: !Sub '${AWS::StackName}-docker-add-tag'
       Description: 'CodeBuild to update the current_release tag in ECR'
       ServiceRole: !Ref CodeBuildRole
       TimeoutInMinutes: 10
@@ -267,7 +272,7 @@ Resources:
   PostDeployGitHub:
     Type: AWS::CodeBuild::Project
     Properties:
-      Name: image_server_docker_add_github_status
+      Name: !Sub '${AWS::StackName}-add-github-status'
       Description: 'CodeBuild to tag the latest commit in repo post-deploy'
       ServiceRole: !Ref CodeBuildRole
       TimeoutInMinutes: 10
@@ -341,7 +346,17 @@ Resources:
             Resource: "*"
           - Effect: Allow
             Action:
-              - codepipeline:*
+              - codepipeline:AcknowledgeJob
+              - codepipeline:GetJobDetails
+              - codepipeline:GetPipeline
+              - codepipeline:GetPipelineState
+              - codepipeline:GetPipelineExecution
+              - codepipeline:ListPipelineExecutions
+              - codepipeline:PollForJobs
+              - codepipeline:PutJobFailureResult
+              - codepipeline:PutJobSuccessResult
+              - codepipeline:RetryStageExecution
+              - codepipeline:StartPipelineExecution
               - sns:Publish
             Resource: '*'
           - Effect: Allow
@@ -375,7 +390,10 @@ Resources:
             Action:
               - ecs:UpdateService
               - ecs:RegisterTaskDefinition
-              - ecs:List*
+              - ecs:ListTasks
+              - ecs:ListTaskDefinitions
+              - ecs:ListClusters
+              - ecs:ListServices
               - ecs:CreateService
             Resource: "*"
       Roles:

--- a/deploy/cloudformation/static-host-pipeline.yml
+++ b/deploy/cloudformation/static-host-pipeline.yml
@@ -72,6 +72,11 @@ Resources:
 
   CodeBuildRole:
     Type: AWS::IAM::Role
+    Metadata:
+      cfn_nag:
+        rules_to_suppress:
+          - id: F3
+            reason: "We're allowing the role to perform all log-related activities."
     Properties:
       AssumeRolePolicyDocument:
         Version: '2012-10-17'
@@ -173,6 +178,11 @@ Resources:
 
   CodeTestDeployRole:
     Type: AWS::IAM::Role
+    Metadata:
+      cfn_nag:
+        rules_to_suppress:
+          - id: F3
+            reason: "We're allowing the role to perform all log-related activities."
     Properties:
       AssumeRolePolicyDocument:
         Version: '2012-10-17'
@@ -236,6 +246,11 @@ Resources:
 
   CodeProdDeployRole:
     Type: AWS::IAM::Role
+    Metadata:
+      cfn_nag:
+        rules_to_suppress:
+          - id: F3
+            reason: "We're allowing the role to perform all log-related activities."
     Properties:
       AssumeRolePolicyDocument:
         Version: '2012-10-17'
@@ -488,7 +503,17 @@ Resources:
             Resource: "*"
           - Effect: Allow
             Action:
-              - codepipeline:*
+              - codepipeline:AcknowledgeJob
+              - codepipeline:GetJobDetails
+              - codepipeline:GetPipeline
+              - codepipeline:GetPipelineState
+              - codepipeline:GetPipelineExecution
+              - codepipeline:ListPipelineExecutions
+              - codepipeline:PollForJobs
+              - codepipeline:PutJobFailureResult
+              - codepipeline:PutJobSuccessResult
+              - codepipeline:RetryStageExecution
+              - codepipeline:StartPipelineExecution
               - sns:Publish
             Resource: '*'
           - Effect: Allow
@@ -517,13 +542,6 @@ Resources:
               - !GetAtt CodeTestDeployer.Arn
               - !GetAtt CodeProdDeployer.Arn
               - !GetAtt PostDeployGitHub.Arn
-          - Effect: Allow
-            Action:
-              - ecs:UpdateService
-              - ecs:RegisterTaskDefinition
-              - ecs:List*
-              - ecs:CreateService
-            Resource: "*"
       Roles:
         - !Ref CodePipelineRole
 


### PR DESCRIPTION
I ran our Mellon templates through [CFN_Nag](https://github.com/stelligent/cfn_nag), which is a Ruby gem that runs some checks against CloudFormation templates. 

I updated the CloudFormation templates to either address the failures reported, or added some Metadata to the template in order to confirm that the behavior was acceptable based on our use-case.

I also parameterized the names of the iiif-service-pipeline CodeBuild resources, as these were hard-coded and meant we could only spin one instance of the pipeline up per region.