### PR TITLE
Change naming of DNS parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ aws cloudformation deploy \
   --stack-name mellon-website-jon \
   --template-file output.yml \
   --capabilities CAPABILITY_IAM \
-  --parameter-overrides SubDomain='mellon-website-dev' \
+  --parameter-overrides HostnamePrefix='mellon-website-dev' \
   --tags ProjectName=mellon Name='testaccount-mellonimagewebsite-dev' \
     Contact='me@myhost.com' Owner='myid' \
     Description='brief-description-of-purpose'
@@ -168,7 +168,7 @@ aws cloudformation deploy \
   --template-file deploy/cloudformation/manifest-pipeline-pipeline.yml \
   --tags Name='mellon-manifest-pipeline' Contact='me@myhost.com' Owner='myid' Description='Deploys the IIIF Manifest Data Pipeline.' \
   --parameter-overrides GitHubToken=my_oauth_key Receivers=me@myhost.com \
-    TestSubDomain='mellon-manifest-test' ProdSubDomain='mellon-manifest' \
+    TestHostnamePrefix='mellon-manifest-test' ProdHostnamePrefix='mellon-manifest' \
     AppConfigPathTest='/all/mellon-manifest-test' AppConfigPathProd='/all/mellon-manifest-prod'
 ```
 

--- a/deploy/cloudformation/app-infrastructure.yml
+++ b/deploy/cloudformation/app-infrastructure.yml
@@ -56,6 +56,8 @@ Resources:
 
   ContainerCluster:
     Type: AWS::ECS::Cluster
+    Properties:
+      ClusterName: !Sub "${AWS::StackName}-Cluster"
 
   ContainerTaskExecutionRole:
     Type: AWS::IAM::Role
@@ -115,12 +117,6 @@ Outputs:
     Value: !Ref SharedLogGroup
     Export:
       Name: !Join [ ':', [ !Ref 'AWS::StackName', 'LogGroup']]
-
-  ClusterName:
-    Description: The name of the ECS Cluster created by this CloudFormation
-    Value: !Ref ContainerCluster
-    Export:
-      Name: !Join [ ':', [ !Ref 'AWS::StackName', 'ClusterName']]
 
   IIIFSecurityGroupID:
     Description: The Security Group ID for the IIIF Service

--- a/deploy/cloudformation/domain.yml
+++ b/deploy/cloudformation/domain.yml
@@ -2,10 +2,10 @@
 AWSTemplateFormatVersion: '2010-09-09'
 
 Description: >
-  Defines a domain and creates a wildcard certificate that can be used for services built in this domain.
+  Defines a domain or subdomain and creates a wildcard certificate that can be used for services built within it.
 
   Note: You will still have to manually create the acm validation record once the zone and certificate are created. If this
-  is a subdomain, you will need to create the ns record in your domain to forward to this zone once it's created. You can do
+  is a subdomain, you will also need to create the ns record in your domain to forward to this zone once it's created. You can do
   this while the stack is waiting for the cert verification, which may take some time if this is a new domain.
 
 Parameters:

--- a/deploy/cloudformation/iiif-service-pipeline.yml
+++ b/deploy/cloudformation/iiif-service-pipeline.yml
@@ -295,7 +295,7 @@ Resources:
             Value: !Sub "https://api.github.com/repos/${SourceRepoOwner}/${SourceRepoName}/statuses"
           - Name: TARGET_HOST
             Type: PARAMETER_STORE
-            Value: !Sub "/all/stacks/${IIIFTestServiceStackName}/hostname"
+            Value: !Sub "/all/stacks/${IIIFProdServiceStackName}/hostname"
 
   CodeS3Bucket:
     Type: AWS::S3::Bucket

--- a/deploy/cloudformation/iiif-service-pipeline.yml
+++ b/deploy/cloudformation/iiif-service-pipeline.yml
@@ -14,11 +14,6 @@ Description: >
 
 Parameters:
 
-  TestURL:
-    Type: 'AWS::SSM::Parameter::Value<String>'
-    Description: The path to the param that stores the test URL.
-    Default: "/all/stacks/mellon-image-service-test/url"
-
   Approvers:
     Type: String
     Default: ''
@@ -57,15 +52,6 @@ Parameters:
     Type: String
     NoEcho: true
     Description: The OAuth Token Value to connect CodePipeline to GitHub. Passed in at Runtime.
-
-  EnvType:
-    Type: String
-    Description: The type of environment to create.
-    Default: dev
-    AllowedValues:
-      - dev
-      - prod
-    ConstraintDescription: must specify prod or dev.
 
 Outputs:
 
@@ -142,7 +128,7 @@ Resources:
                         - !GetAtt CodeS3Bucket.Arn
                         - "/*"
         -
-          PolicyName: "ReadGitOauth"
+          PolicyName: "ReadRequiredSSM"
           PolicyDocument:
             Version: '2012-10-17'
             Statement:
@@ -150,7 +136,9 @@ Resources:
                 Effect: Allow
                 Action:
                   - ssm:GetParameters
-                Resource: !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/esu/github/ndlib-git/oauth"
+                Resource:
+                  - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/esu/github/ndlib-git/oauth"
+                  - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/all/stacks/${IIIFTestServiceStackName}/hostname"
 
 
   DockerQABuilder:
@@ -176,7 +164,7 @@ Resources:
               commands:
                 - echo Build started on `date`
                 - |
-                  printf '{"name": "image_server.test","values": [{"key": "image-server-host","value": "%s:8182"}, {"key": "image-server-protocol","value": "https"}],"_postman_variable_scope": "environment"}' $TESTING_URL >> test_env.json
+                  printf '{"name": "image_server.test","values": [{"key": "image-server-host","value": "%s:8182"}, {"key": "image-server-protocol","value": "https"}],"_postman_variable_scope": "environment"}' $TESTING_HOST >> test_env.json
                 - cat test_env.json
                 - newman run spec/image-server.postman_collection.json -e test_env.json
             post_build:
@@ -189,8 +177,9 @@ Resources:
         ComputeType: BUILD_GENERAL1_SMALL
         Image: aws/codebuild/nodejs:10.1.0
         EnvironmentVariables:
-          - Name: TESTING_URL
-            Value: !Ref TestURL
+          - Name: TESTING_HOST
+            Type: PARAMETER_STORE
+            Value: !Sub "/all/stacks/${IIIFTestServiceStackName}/hostname"
 
   DockerCodePipelineBuilder:
     Type: 'AWS::CodeBuild::Project'
@@ -291,7 +280,7 @@ Resources:
                 - DATE=$(date)
             post_build:
               commands:
-                - curl -i -X POST -H "Authorization:token ${OAUTH_TOKEN}" "${API_URL}/${SOURCE_SHA}" -d "{\"state\":\"success\",\"description\":\"Deployed to production on ${DATE}\",\"context\":\"${CODEBUILD_INITIATOR}\",\"target_url\":\"https://${TARGET_URL}\"}"
+                - curl -i -X POST -H "Authorization:token ${OAUTH_TOKEN}" "${API_URL}/${SOURCE_SHA}" -d "{\"state\":\"success\",\"description\":\"Deployed to production on ${DATE}\",\"context\":\"${CODEBUILD_INITIATOR}\",\"target_url\":\"https://${TARGET_HOST}\"}"
       Artifacts:
         Type: CODEPIPELINE
       Environment:
@@ -304,9 +293,9 @@ Resources:
             Value: /esu/github/ndlib-git/oauth
           - Name: API_URL
             Value: !Sub "https://api.github.com/repos/${SourceRepoOwner}/${SourceRepoName}/statuses"
-          - Name: TARGET_URL
-            Value:
-              Fn::ImportValue: !Join [':', [!Ref IIIFProdServiceStackName, 'URL']]
+          - Name: TARGET_HOST
+            Type: PARAMETER_STORE
+            Value: !Sub "/all/stacks/${IIIFTestServiceStackName}/hostname"
 
   CodeS3Bucket:
     Type: AWS::S3::Bucket
@@ -453,10 +442,8 @@ Resources:
                 Provider: ECS
                 Version: "1"
               Configuration:
-                ClusterName:
-                  Fn::ImportValue: !Join [':', [!Ref InfrastructureStackName, 'ClusterName']]
-                ServiceName:
-                  Fn::Join: ['-', [!Ref IIIFTestServiceStackName, 'ImageService']]
+                ClusterName: !Sub '${InfrastructureStackName}-Cluster'
+                ServiceName: !Sub '${IIIFTestServiceStackName}-ImageService'
                 FileName: imagedefinitionstest.json
         -
           Name: Approval
@@ -497,10 +484,8 @@ Resources:
                 Provider: ECS
                 Version: "1"
               Configuration:
-                ClusterName:
-                  Fn::ImportValue: !Join [':', [!Ref InfrastructureStackName, 'ClusterName']]
-                ServiceName:
-                  Fn::Join: ['-', [!Ref IIIFProdServiceStackName, 'ImageService']]
+                ClusterName: !Sub '${InfrastructureStackName}-Cluster'
+                ServiceName: !Sub '${IIIFProdServiceStackName}-ImageService'
                 FileName: imagedefinitionsprod.json
         -
           Name: PostDeployActions

--- a/deploy/cloudformation/iiif-service.yml
+++ b/deploy/cloudformation/iiif-service.yml
@@ -7,7 +7,6 @@ Description: >
 
   Expects the following exports from the app-infrastructure stack:
     - InfrastructureStackName:ContainerTaskExecutionRoleArn
-    - InfrastructureStackName:ClusterName
     - InfrastructureStackName:IIIFSecurityGroupID
     - InfrastructureStackName:ContainerTaskExecutionRoleArn
     - InfrastructureStackName:PublicLoadBalancerSecurityGroup
@@ -75,9 +74,12 @@ Parameters:
     Type: Number
     Default: 1
     Description: How many copies of the service task to run
-  SubDomain:
+  HostnamePrefix:
     Type: String
-    Description: The SubDomain of the service. Combined with DomainName to create the FQDN.
+    Description: Hostname prefix for the manifest bucket CDN
+    MaxLength: 63
+    AllowedPattern: ^$|(?!-)[a-zA-Z0-9-.]{1,63}(?<!-)
+    ConstraintDescription: Must be a valid hostname prefix value.
   CreateDNSRecord:
     Type: String
     Default: 'True'
@@ -91,37 +93,28 @@ Outputs:
     Description: The dns name of the load balancer
     Value: !GetAtt PublicLoadBalancer.DNSName
 
-  WebURL:
-    Description: The URL of the service, often in CNAME form
-    Value: !Sub
-        - '${SubDomain}.${ResolvedDomainName}'
-        - ResolvedDomainName:
-            Fn::ImportValue: !Sub '${DomainStackName}:DomainName'
-    Export:
-      Name: !Join [ ':', [!Ref 'AWS::StackName', 'URL']]
-
   ImageDerivativeCacheBucketName:
     Description: The name of the bucket that will be used as the source/destination for derivative images
     Value: !Ref ImageDerivativeCacheBucket
 
-  SubDomain:
-    Description: The SubDomain of the ECS Service
+  Service:
+    Description: The name of the ECS Service
     Value: !Ref Service
     Export:
       Name: !Join [ ':', [ !Ref 'AWS::StackName', 'Service']]
 
 Resources:
 
-  URLParameter:
+  HostnameParameter:
     Type: AWS::SSM::Parameter
     Properties:
       Type: String
-      Name: !Sub "/all/stacks/${AWS::StackName}/url"
+      Name: !Sub "/all/stacks/${AWS::StackName}/hostname"
       Value: !Sub
-        - '${SubDomain}.${ResolvedDomainName}'
+        - '${HostnamePrefix}.${ResolvedDomainName}'
         - ResolvedDomainName:
             Fn::ImportValue: !Sub '${DomainStackName}:DomainName'
-      Description: The URL endpoint for this component
+      Description: The hostname for this component
 
   # The task definition. This is a simple metadata description of what
   # container to run, and what resource requirements it has.
@@ -167,8 +160,7 @@ Resources:
     DependsOn: LoadBalancerRule
     Properties:
       ServiceName: !Sub '${AWS::StackName}-ImageService'
-      Cluster:
-        Fn::ImportValue: !Join [':', [!Ref InfrastructureStackName, 'ClusterName']]
+      Cluster: !Sub '${InfrastructureStackName}-Cluster'
       LaunchType: FARGATE
       DeploymentConfiguration:
         MaximumPercent: 200
@@ -324,11 +316,11 @@ Resources:
         - ResolvedDomainName:
             Fn::ImportValue: !Sub '${DomainStackName}:DomainName'
       Comment: !Sub
-        - '${SubDomain}.${ResolvedDomainName}'
+        - '${HostnamePrefix}.${ResolvedDomainName}'
         - ResolvedDomainName:
             Fn::ImportValue: !Sub '${DomainStackName}:DomainName'
       Name: !Sub
-        - '${SubDomain}.${ResolvedDomainName}'
+        - '${HostnamePrefix}.${ResolvedDomainName}'
         - ResolvedDomainName:
             Fn::ImportValue: !Sub '${DomainStackName}:DomainName'
       Type: CNAME

--- a/deploy/cloudformation/manifest-pipeline-pipeline.yml
+++ b/deploy/cloudformation/manifest-pipeline-pipeline.yml
@@ -22,23 +22,23 @@ Parameters:
     Description: The name of the CloudFormation stack to use when creating the production resources
     Default: "mellon-manifest-prod"
     MaxLength: 24
-  ProdSubDomain:
+  ProdHostnamePrefix:
     Type: String
-    Description: Host DNS name for website without Domain
+    Description: Hostname prefix for the production manifest bucket CDN
     MaxLength: 63
     AllowedPattern: ^$|(?!-)[a-zA-Z0-9-.]{1,63}(?<!-)
-    ConstraintDescription: Must be a valid SubDomain value.
+    ConstraintDescription: Must be a valid hostname prefix.
   TestStackName:
     Type: String
     Description: The name of the CloudFormation stack to use when creating the test resources
     Default: "mellon-manifest-test"
     MaxLength: 24
-  TestSubDomain:
+  TestHostnamePrefix:
     Type: String
-    Description: Host DNS name for website without Domain
+    Description: Hostname prefix for the test manifest bucket CDN
     MaxLength: 63
     AllowedPattern: ^$|(?!-)[a-zA-Z0-9-.]{1,63}(?<!-)
-    ConstraintDescription: Must be a valid SubDomain value.
+    ConstraintDescription: Must be a valid hostname prefix.
   CreateDNSRecord:
     Type: String
     Default: "True"
@@ -366,8 +366,8 @@ Resources:
                       \"Parameters\" : {
                         \"AppConfigPath\" : \"${AppConfigPathTest}\",
                         \"ImageSourceBucket\" : \"/all/stacks/${DataBrokerStackName}/publicbucket\",
-                        \"ImageServerUrl\" : \"/all/stacks/${ImageServiceTestStackName}/url\",
-                        \"SubDomain\" : \"${TestSubDomain}\",
+                        \"ImageServerHostname\" : \"/all/stacks/${ImageServiceTestStackName}/hostname\",
+                        \"HostnamePrefix\" : \"${TestHostnamePrefix}\",
                         \"DomainStackName\" : \"${DomainStackName}\",
                         \"CreateDNSRecord\" : \"${CreateDNSRecord}\"
                       },
@@ -383,8 +383,8 @@ Resources:
                       \"Parameters\" : {
                         \"AppConfigPath\" : \"${AppConfigPathProd}\",
                         \"ImageSourceBucket\" : \"/all/stacks/${DataBrokerStackName}/publicbucket\",
-                        \"ImageServerUrl\" : \"/all/stacks/${ImageServiceProdStackName}/url\",
-                        \"SubDomain\" : \"${ProdSubDomain}\",
+                        \"ImageServerHostname\" : \"/all/stacks/${ImageServiceProdStackName}/hostname\",
+                        \"HostnamePrefix\" : \"${ProdHostnamePrefix}\",
                         \"DomainStackName\" : \"${DomainStackName}\",
                         \"CreateDNSRecord\" : \"${CreateDNSRecord}\"
                       },

--- a/deploy/cloudformation/manifest-pipeline.yml
+++ b/deploy/cloudformation/manifest-pipeline.yml
@@ -22,10 +22,10 @@ Parameters:
     Type: 'AWS::SSM::Parameter::Value<String>'
     Description: The name of the source bucket that the IIIF Image service will read from for its assets.
     Default: '/all/stacks/mellon-data-broker/publicbucket'
-  ImageServerUrl:
+  ImageServerHostname:
     Type: 'AWS::SSM::Parameter::Value<String>'
-    Description: The url of the IIIF Image Server
-    Default: '/all/stacks/mellon-image-service/url'
+    Description: The hostname of the IIIF Image Server
+    Default: '/all/stacks/mellon-image-service/hostname'
   InfrastructureStackName:
     Type: String
     Default: "mellon-app-infrastructure"
@@ -45,12 +45,12 @@ Parameters:
     Default: "True"
     Description: If True, will attempt to create a Route 53 DNS record for the CloudFront.
 
-  SubDomain:
+  HostnamePrefix:
     Type: String
-    Description: Host DNS name for website without Domain
+    Description: Hostname prefix for the manifest bucket CDN
     MaxLength: 63
     AllowedPattern: ^$|(?!-)[a-zA-Z0-9-.]{1,63}(?<!-)
-    ConstraintDescription: Must be a valid SubDomain value.
+    ConstraintDescription: Must be a valid hostname prefix value.
 
 Conditions:
 
@@ -66,14 +66,14 @@ Outputs:
   ManifestBucket:
     Value: !Ref ManifestBucket
 
-  URL:
-    Description: The combination of SubDomain and Domain
+  Hostname:
+    Description: The combination of HostnamePrefix and Domain
     Value: !Sub
-        - '${SubDomain}.${ResolvedDomainName}'
+        - '${HostnamePrefix}.${ResolvedDomainName}'
         - ResolvedDomainName:
             Fn::ImportValue: !Sub '${DomainStackName}:DomainName'
     Export:
-      Name: !Join [ ':', [ !Ref 'AWS::StackName', 'URL']]
+      Name: !Join [ ':', [ !Ref 'AWS::StackName', 'Hostname']]
 
   DistributionDomainName:
     Description: The cloudfront distribution domain name. Use this if creating your CNAME record via some other DNS
@@ -86,7 +86,7 @@ Resources:
     Properties:
       Type: String
       Name: !Sub "${AppConfigPath}/image-server-base-url"
-      Value: !Ref ImageServerUrl
+      Value: !Ref ImageServerHostname
       Description: Image server base url
 
   SSMImageSourceBucket:
@@ -102,7 +102,10 @@ Resources:
     Properties:
       Type: String
       Name: !Sub "${AppConfigPath}/manifest-server-base-url"
-      Value: !GetAtt Distribution.DomainName
+      Value: !Sub
+        - '${HostnamePrefix}.${ResolvedDomainName}'
+        - ResolvedDomainName:
+            Fn::ImportValue: !Sub '${DomainStackName}:DomainName'
       Description: Manifest Server URL
 
   SSMManifestBucket:
@@ -178,11 +181,11 @@ Resources:
         - ResolvedDomainName:
             Fn::ImportValue: !Sub '${DomainStackName}:DomainName'
       Comment: !Sub
-        - '${SubDomain}.${ResolvedDomainName}'
+        - '${HostnamePrefix}.${ResolvedDomainName}'
         - ResolvedDomainName:
             Fn::ImportValue: !Sub '${DomainStackName}:DomainName'
       Name: !Sub
-        - '${SubDomain}.${ResolvedDomainName}'
+        - '${HostnamePrefix}.${ResolvedDomainName}'
         - ResolvedDomainName:
             Fn::ImportValue: !Sub '${DomainStackName}:DomainName'
       Type: CNAME
@@ -211,12 +214,12 @@ Resources:
           MinimumProtocolVersion: TLSv1.1_2016
           SslSupportMethod: sni-only
         Comment: !Sub
-          - '${SubDomain}.${ResolvedDomainName}'
+          - '${HostnamePrefix}.${ResolvedDomainName}'
           - ResolvedDomainName:
               Fn::ImportValue: !Sub '${DomainStackName}:DomainName'
         Aliases:
           - !Sub
-            - '${SubDomain}.${ResolvedDomainName}'
+            - '${HostnamePrefix}.${ResolvedDomainName}'
             - ResolvedDomainName:
                 Fn::ImportValue: !Sub '${DomainStackName}:DomainName'
         DefaultRootObject: index.json
@@ -258,7 +261,7 @@ Resources:
               - s3
               - !Ref AWS::URLSuffix
           Prefix: !Sub
-            - 'web/${SubDomain}.${ResolvedDomainName}/'
+            - 'web/${HostnamePrefix}.${ResolvedDomainName}/'
             - ResolvedDomainName:
                 Fn::ImportValue: !Sub '${DomainStackName}:DomainName'
           IncludeCookies: true

--- a/deploy/cloudformation/static-host-pipeline.yml
+++ b/deploy/cloudformation/static-host-pipeline.yml
@@ -429,7 +429,7 @@ Resources:
   PostDeployGitHub:
     Type: AWS::CodeBuild::Project
     Properties:
-      Name: add_github_status
+      Name: !Sub '${AWS::StackName}-PostDeployGitHub'
       Description: 'CodeBuild to tag the latest commit in repo post-deploy'
       ServiceRole: !Ref CodeBuildRole
       TimeoutInMinutes: 10
@@ -448,7 +448,7 @@ Resources:
                 - DATE=$(date)
             post_build:
               commands:
-                - curl -i -X POST -H "Authorization:token ${OAUTH_TOKEN}" "${API_URL}/${SOURCE_SHA}" -d "{\"state\":\"success\",\"description\":\"Deployed to production on ${DATE}\",\"context\":\"${CODEBUILD_INITIATOR}\",\"target_url\":\"https://${TARGET_URL}\"}"
+                - curl -i -X POST -H "Authorization:token ${OAUTH_TOKEN}" "${API_URL}/${SOURCE_SHA}" -d "{\"state\":\"success\",\"description\":\"Deployed to production on ${DATE}\",\"context\":\"${CODEBUILD_INITIATOR}\",\"target_url\":\"https://${TARGET_HOST}\"}"
       Artifacts:
         Type: CODEPIPELINE
       Environment:
@@ -461,9 +461,9 @@ Resources:
             Value: /esu/github/ndlib-git/oauth
           - Name: API_URL
             Value: !Sub "https://api.github.com/repos/${SourceRepoOwner}/${SourceRepoName}/statuses"
-          - Name: TARGET_URL
+          - Name: TARGET_HOST
             Value:
-              Fn::ImportValue: !Join [':', [!Ref ProdStackName, 'URL']]
+              Fn::ImportValue: !Join [':', [!Ref ProdStackName, 'Hostname']]
 
   CodeS3Bucket:
     Type: AWS::S3::Bucket
@@ -616,11 +616,11 @@ Resources:
                 NotificationArn: !Ref ApproversTopic
                 CustomData:
                   Fn::Sub:
-                    - "You can review these changes at https://${TestURL}. Once approved, this will be deployed to https://${ProdURL}."
-                    - TestURL:
-                        Fn::ImportValue: !Join [':', [!Ref TestStackName, 'URL']]
-                      ProdURL:
-                        Fn::ImportValue: !Join [':', [!Ref ProdStackName, 'URL']]
+                    - "You can review these changes at https://${TestHostname}. Once approved, this will be deployed to https://${ProdHostname}."
+                    - TestHostname:
+                        Fn::ImportValue: !Join [':', [!Ref TestStackName, 'Hostname']]
+                      ProdHostname:
+                        Fn::ImportValue: !Join [':', [!Ref ProdStackName, 'Hostname']]
 
         -
           Name: DeployToProduction

--- a/deploy/cloudformation/static-host.yml
+++ b/deploy/cloudformation/static-host.yml
@@ -24,12 +24,12 @@ Parameters:
     Default: "True"
     Description: If True, will attempt to create a Route 53 DNS record for the CloudFront.
 
-  SubDomain:
+  HostnamePrefix:
     Type: String
-    Description: Host DNS name for website without Domain
+    Description: Hostname prefix for the website CDN
     MaxLength: 63
     AllowedPattern: ^$|(?!-)[a-zA-Z0-9-.]{1,63}(?<!-)
-    ConstraintDescription: Must be a valid SubDomain value.
+    ConstraintDescription: Must be a valid hostname prefix value.
 
   EnvType:
     Type: String
@@ -59,14 +59,14 @@ Outputs:
     Export:
       Name: !Join [ ':', [ !Ref 'AWS::StackName', 'BucketName']]
 
-  URL:
-    Description: The combination of SubDomain and Domain
+  Hostname:
+    Description: The combination of HostnamePrefix and Domain
     Value: !Sub
-        - '${SubDomain}.${ResolvedDomainName}'
+        - '${HostnamePrefix}.${ResolvedDomainName}'
         - ResolvedDomainName:
             Fn::ImportValue: !Sub '${DomainStackName}:DomainName'
     Export:
-      Name: !Join [ ':', [ !Ref 'AWS::StackName', 'URL']]
+      Name: !Join [ ':', [ !Ref 'AWS::StackName', 'Hostname']]
 
   DistributionDomainName:
     Description: The cloudfront distribution domain name.
@@ -87,7 +87,7 @@ Resources:
         DestinationBucketName:
           Fn::ImportValue: !Join [':', [!Ref InfrastructureStackName, 'LogBucket']]
         LogFilePrefix: !Sub
-            - 's3/${SubDomain}.${ResolvedDomainName}/'
+            - 's3/${HostnamePrefix}.${ResolvedDomainName}/'
             - ResolvedDomainName:
                 Fn::ImportValue: !Sub '${DomainStackName}:DomainName'
 
@@ -120,12 +120,12 @@ Resources:
           MinimumProtocolVersion: TLSv1.1_2016
           SslSupportMethod: sni-only
         Comment: !Sub
-            - '${SubDomain}.${ResolvedDomainName}'
+            - '${HostnamePrefix}.${ResolvedDomainName}'
             - ResolvedDomainName:
                 Fn::ImportValue: !Sub '${DomainStackName}:DomainName'
         Aliases:
           - !Sub
-              - '${SubDomain}.${ResolvedDomainName}'
+              - '${HostnamePrefix}.${ResolvedDomainName}'
               - ResolvedDomainName:
                   Fn::ImportValue: !Sub '${DomainStackName}:DomainName'
         DefaultRootObject: index.html
@@ -159,7 +159,7 @@ Resources:
               - s3
               - !Ref AWS::URLSuffix
           Prefix: !Sub
-               - 'web/${SubDomain}.${ResolvedDomainName}/'
+               - 'web/${HostnamePrefix}.${ResolvedDomainName}/'
                - ResolvedDomainName:
                    Fn::ImportValue: !Sub '${DomainStackName}:DomainName'
           IncludeCookies: true
@@ -173,11 +173,11 @@ Resources:
         - ResolvedDomainName:
             Fn::ImportValue: !Sub '${DomainStackName}:DomainName'
       Comment: !Sub
-        - '${SubDomain}.${ResolvedDomainName}'
+        - '${HostnamePrefix}.${ResolvedDomainName}'
         - ResolvedDomainName:
             Fn::ImportValue: !Sub '${DomainStackName}:DomainName'
       Name: !Sub
-        - '${SubDomain}.${ResolvedDomainName}'
+        - '${HostnamePrefix}.${ResolvedDomainName}'
         - ResolvedDomainName:
             Fn::ImportValue: !Sub '${DomainStackName}:DomainName'
       Type: CNAME

--- a/deploy/cloudformation/unified-static-host.yml
+++ b/deploy/cloudformation/unified-static-host.yml
@@ -24,12 +24,12 @@ Parameters:
     Default: "True"
     Description: If True, will attempt to create a Route 53 DNS record for the CloudFront.
 
-  SubDomain:
+  HostnamePrefix:
     Type: String
-    Description: Host DNS name for website without Domain
+    Description: Hostname prefix for the website CDN
     MaxLength: 63
     AllowedPattern: ^$|(?!-)[a-zA-Z0-9-.]{1,63}(?<!-)
-    ConstraintDescription: Must be a valid SubDomain value.
+    ConstraintDescription: Must be a valid hostname prefix value.
 
   EnvType:
     Type: String
@@ -59,14 +59,14 @@ Outputs:
     Export:
       Name: !Join [ ':', [ !Ref 'AWS::StackName', 'BucketName']]
 
-  URL:
+  Hostname:
     Description: The FQDN if one is given, otherwise the cloudfront distribution domain name.
     Value: !Sub
-        - '${SubDomain}.${ResolvedDomainName}'
+        - '${HostnamePrefix}.${ResolvedDomainName}'
         - ResolvedDomainName:
             Fn::ImportValue: !Sub '${DomainStackName}:DomainName'
     Export:
-      Name: !Join [ ':', [ !Ref 'AWS::StackName', 'URL']]
+      Name: !Join [ ':', [ !Ref 'AWS::StackName', 'Hostname']]
 
   DistributionDomainName:
     Description: The cloudfront distribution domain name.
@@ -87,7 +87,7 @@ Resources:
         DestinationBucketName:
           Fn::ImportValue: !Join [':', [!Ref InfrastructureStackName, 'LogBucket']]
         LogFilePrefix: !Sub
-            - 's3/${SubDomain}.${ResolvedDomainName}/'
+            - 's3/${HostnamePrefix}.${ResolvedDomainName}/'
             - ResolvedDomainName:
                 Fn::ImportValue: !Sub '${DomainStackName}:DomainName'
 
@@ -114,11 +114,11 @@ Resources:
         - ResolvedDomainName:
             Fn::ImportValue: !Sub '${DomainStackName}:DomainName'
       Comment: !Sub
-        - '${SubDomain}.${ResolvedDomainName}'
+        - '${HostnamePrefix}.${ResolvedDomainName}'
         - ResolvedDomainName:
             Fn::ImportValue: !Sub '${DomainStackName}:DomainName'
       Name: !Sub
-        - '${SubDomain}.${ResolvedDomainName}'
+        - '${HostnamePrefix}.${ResolvedDomainName}'
         - ResolvedDomainName:
             Fn::ImportValue: !Sub '${DomainStackName}:DomainName'
       Type: CNAME
@@ -139,12 +139,12 @@ Resources:
           MinimumProtocolVersion: TLSv1.1_2016
           SslSupportMethod: sni-only
         Comment: !Sub
-            - '${SubDomain}.${ResolvedDomainName}'
+            - '${HostnamePrefix}.${ResolvedDomainName}'
             - ResolvedDomainName:
                 Fn::ImportValue: !Sub '${DomainStackName}:DomainName'
         Aliases:
           - !Sub
-              - '${SubDomain}.${ResolvedDomainName}'
+              - '${HostnamePrefix}.${ResolvedDomainName}'
               - ResolvedDomainName:
                   Fn::ImportValue: !Sub '${DomainStackName}:DomainName'
         DefaultRootObject: index.html
@@ -182,7 +182,7 @@ Resources:
               - s3
               - !Ref AWS::URLSuffix
           Prefix: !Sub
-               - 'web/${SubDomain}.${ResolvedDomainName}/'
+               - 'web/${HostnamePrefix}.${ResolvedDomainName}/'
                - ResolvedDomainName:
                    Fn::ImportValue: !Sub '${DomainStackName}:DomainName'
           IncludeCookies: true


### PR DESCRIPTION
Now that we’ve landed on a domain stack to handle domains/subdomains, the SubDomain parameter in all of the service stacks will only ever be prefixes. This primarily changes the naming of the SubDomain param to HostnamePrefix, with a few other pieces of cleanup. Changes:

**domain.yml:**
- Added additional language to the domain template to be clear that it will handle either domain or subdomains for the services built on top of it

**iiif-service.yml:**
- Changed to use HostnamePrefix, and also changed things like URL to hostname. The URL export/ssm are hold over from older templates and aren’t really reflective of the type of value thats being exported
- Cleaned up some overlap with how the hostname was both exported and added to ssm. Removed the export and fixed the pipeline to read from ssm for this value

**app-infrastructure.yml:**
- Changed the cluster to be explicitly named, so that we can rely on naming convention instead of an export to get the cluster name in iiif-service and iiif-service-pipeline. This will now require replacement on update, but given that a cluster has no other properties, it shouldn’t be an issue.

**manifest-pipeline.yml:**
- Changed URL references to hostname and SubDomain to HostnamePrefix
- Changed SSMImageSourceBucket to use the full hostname in DNS so that the manifest pipeline uses the full domain name instead of the cloudfront name.

**manifest-pipeline-pipeline.yml:**
- Changed to require the hostname prefix to use when creating the test/prod manifest buckets. Had to change the generated stack config in the code build to match these changes.

**static-host, unified-static-host, and static-host-pipeline:**
- Updated to use hostname and hostname prefix instead of URL and SubDomain
- Fixed a naming collision for the static-host-pipeline’s post deploy code build

**README.md:**
- Changed all references to SubDomain in the README to HostnamePrefix