### PR TITLE
update the buildspec to use the InfrastructureStackName parameter

### DIFF
--- a/deploy/cloudformation/manifest-pipeline-pipeline.yml
+++ b/deploy/cloudformation/manifest-pipeline-pipeline.yml
@@ -369,7 +369,8 @@ Resources:
                         \"ImageServerHostname\" : \"/all/stacks/${ImageServiceTestStackName}/hostname\",
                         \"HostnamePrefix\" : \"${TestHostnamePrefix}\",
                         \"DomainStackName\" : \"${DomainStackName}\",
-                        \"CreateDNSRecord\" : \"${CreateDNSRecord}\"
+                        \"CreateDNSRecord\" : \"${CreateDNSRecord}\",
+                        \"InfrastructureStackName\" : \"${InfrastructureStackName}\"
                       },
                       \"Tags\" : {
                         \"Name\" : \"${TestStackName}\",
@@ -386,7 +387,8 @@ Resources:
                         \"ImageServerHostname\" : \"/all/stacks/${ImageServiceProdStackName}/hostname\",
                         \"HostnamePrefix\" : \"${ProdHostnamePrefix}\",
                         \"DomainStackName\" : \"${DomainStackName}\",
-                        \"CreateDNSRecord\" : \"${CreateDNSRecord}\"
+                        \"CreateDNSRecord\" : \"${CreateDNSRecord}\",
+                        \"InfrastructureStackName\" : \"${InfrastructureStackName}\"
                       },
                       \"Tags\" : {
                         \"Name\" : \"${ProdStackName}\",


### PR DESCRIPTION
This addresses a minor issue in the v2019.2 pre-release where the CodeBuild was not respecting the `InfrastructureStackName` parameter from the manifest-pipeline-pipeline.yml and resulted in it only being possible to deploy one instantiation of the manifest-pipeline-pipeline.yml stack.