### PR TITLE
Bug fixes related to rebuild

### DIFF
--- a/deploy/cloudformation/iiif-service-pipeline.yml
+++ b/deploy/cloudformation/iiif-service-pipeline.yml
@@ -139,6 +139,7 @@ Resources:
                 Resource:
                   - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/esu/github/ndlib-git/oauth"
                   - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/all/stacks/${IIIFTestServiceStackName}/hostname"
+                  - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/all/stacks/${IIIFProdServiceStackName}/hostname"
 
 
   DockerQABuilder:

--- a/deploy/cloudformation/manifest-pipeline-pipeline.yml
+++ b/deploy/cloudformation/manifest-pipeline-pipeline.yml
@@ -244,10 +244,7 @@ Resources:
           - Action:
               - 'route53:ChangeResourceRecordSets'
               - 'route53:ListResourceRecordSets'
-            Resource: !Sub
-              - 'arn:aws:route53:::hostedzone/${ResolvedZone}'
-              - ResolvedZone:
-                  Fn::ImportValue: !Join [':', [!Ref DomainStackName, 'Zone']]
+            Resource: 'arn:aws:route53:::hostedzone/*'
             Effect: Allow
           - Action:
               - 'route53:ListHostedZones'


### PR DESCRIPTION
During yesterday's deploy, encountered a few issues with building everything back up. The image service pipeline was unable to read from SSM for the prod host name when posting to github. Additionally, when deploying without creating the dns zone, the domain stack will not have a Zone export. This currently breaks the manifest code pipeline. Had to remove this dependency to get it working. We need to revisit this, but the best solution I could determine to work with both paths is to just allow all. This should not be a security issue in our production account for now, since the code pipeline is not creating DNS record sets, but we'll want to fix this before we redeploy to our development account.